### PR TITLE
Added Installation/Getting Stared page, restructered things a bit

### DIFF
--- a/docs/clients_and_tools.rst
+++ b/docs/clients_and_tools.rst
@@ -1,0 +1,16 @@
+Clients and Tools
+=================
+
+
+Gladier Clients
+---------------
+
+This section will describe the nitty gritty details of clients!
+
+Gladier Tools
+-------------
+
+This section will describe the nitty gritty details of tools!
+
+
+

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -1,5 +1,5 @@
-Infrastructure
-==============
+Glossary
+========
 
 **Gladier** builds on a science services framework, in the form of Globus Auth, Transfer, Search, Groups, and Flows, plus funcX function-as-a-service. 
 These services provide a reliable, secure, and high-performance substrate to access and manage data and computing resources. Here we highlight

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,8 +17,10 @@ systems at APS, ALCF, and elsewhere, all managed by cloud-hosted Globus services
    :maxdepth: 2
    :caption: Contents:
 
-   infrastructure
+   installation
+   clients_and_tools
    tools/index
+   glossary
 
 
 Indices and tables

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,80 @@
+Installation
+============
+
+Gladier requires Python 3.6 and higher. For a modern version of python,
+see the official `Python Installation Guide <https://docs.python-guide.org/starting/installation/>`_.
+
+The easiest way to get Gladier is through Pip on PyPi. Gladier is built with two
+main packages, the core Gladier client and Gladier Tools. Gladier Tools include
+a set of reusable, common operations. Installing it is highly recommended.
+
+With pip installed, you can do the following:
+
+
+.. code-block:: bash
+
+   pip install gladier gladier-tools
+
+Getting Started
+===============
+
+With Gladier Installed, you can now put together some basic clients!
+Setup your workflow by overriding the Gladier Client with a list of the
+tools you want to use. An example looks like this:
+
+.. literalinclude:: tools/gladier_example.py
+   :language: python
+   :pyobject: HelloGladier
+
+
+The new class has two main attributes:
+
+* ``gladier_tools`` -- Defines which tools you want to use for this client
+* ``flow_definition`` -- Defines how automate will run your tools
+
+You may notice that both have similar values, ``gladier.tools.hello_world.HelloWorld``.
+Each Gladier tool comes with its own built-in flow so it can easily be tested separately.
+Gladier Tools also contain their own ``required_input``, default ``flow_input``, and
+defined ``funcx_functions``.
+
+More on these components later. For now, let's run the flow!
+
+.. code-block:: python
+
+   hello_cli = HelloGladier()
+   flow = hello_cli.start_flow()
+
+The first line instantiates the client with default values, which means it will automatically
+trigger login for Globus Auth and register Flows and FuncX functions as needed, without asking.
+
+The second line, ``flow = hello_cli.start_flow()``, iterates over all defined tools and starts the flow. A bunch of things happen
+here, including:
+
+* Gathering input from each tool
+* Validating input for each tool
+* Triggering a login, if needed
+* Registering funcx functions (And re-registering, if they have changed)
+* Registering the ``flow_definition`` (And re-registering, if it has changed)
+* Starting the flow
+
+Now, the flow will run and complete. This is great, but it would be nice to get more details on
+whats happening. The GladierClient comes with some built-in functions to help with this:
+
+
+.. code-block:: python
+
+  hello_cli.progress(flow['action_id'])
+  details = hello_cli.get_details(flow['action_id'], 'HelloFuncXResult')
+  pprint(details)
+
+``progress()`` will periodically query the status of the flow until it finishes. It's
+a nice way to watch progression as the flow executes. Once the flow has finished,
+``get_details()`` will fetch output from the Globus Flow, so it can be displayed in a
+readable format.
+Running A Gladier Tool
+----------------------
+
+A full code snippet for running everything above is here:
+
+.. literalinclude:: tools/gladier_example.py
+   :language: python

--- a/docs/tools/gladier_example.py
+++ b/docs/tools/gladier_example.py
@@ -3,7 +3,6 @@ from pprint import pprint
 
 
 class HelloGladier(GladierClient):
-    client_id = 'e6c75d97-532a-4c88-b031-8584a319fa3e'
     gladier_tools = [
         'gladier.tools.hello_world.HelloWorld',
     ]

--- a/docs/tools/index.rst
+++ b/docs/tools/index.rst
@@ -1,5 +1,5 @@
-Gladier Tools
-=============
+List of Built-In Gladier Tools
+==============================
 
 Gladier tools are reusable components that can be strung together to create
 a new workflow. Each flow may be unique, but the components of a
@@ -16,38 +16,3 @@ Each Gladier tool is a set of two things:
 
    hello_world/index
    manifest/index
-
-
-Configuring A Gladier Tool
---------------------------
-
-Setup your workflow by overriding the Gladier Client with a list of the
-tools you want to use. An example looks like this:
-
-.. literalinclude:: gladier_example.py
-   :language: python
-   :pyobject: HelloGladier
-
-The Gladier Client has built-in functions for automatically registering
-and deploying FuncX functions and Automate Flows. Running the example
-above looks like this:
-
-.. code-block:: python
-
-   hello_cli = HelloGladier()
-   flow = hello_cli.start_flow()
-
-Automatic registration and login are turned on by default when instantiating
-``HelloGladier``. See REFERENCE NEEDED for more information.
-
-``hello_cli.start_flow()`` will fetch all the tools needed, register funcx
-functions, generate default input for each tool, register the Automate Flow,
-and start it.
-
-Running A Gladier Tool
-----------------------
-
-A full code snippet for running everything above is here:
-
-.. literalinclude:: gladier_example.py
-   :language: python


### PR DESCRIPTION
Added an installation page for showing new users how to install
Gladier, and a quick 5 minutes getting started guide. The purpose
behind these changes is to get users running Gladier as quickly
as possible, without explaining all the details of how Gladier works.

Once users can run the basic 'hello world' flow, we can teach them
about how various components can be customized