### PR TITLE
Set funcx reqs to funcx==0.0.5 to fix permissions error running funcx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-funcx>=0.0.5
+funcx==0.0.5
 globus-automate-client>=0.10.6


### PR DESCRIPTION
funcx-0.2.2 is now on pypi, and it causes problems for some reason