### PR TITLE
Move to private config

### DIFF
--- a/gladier/client.py
+++ b/gladier/client.py
@@ -43,9 +43,11 @@ class GladierBaseClient(object):
     client_id = 'e6c75d97-532a-4c88-b031-8584a319fa3e'
 
     def __init__(self, authorizers=None, auto_login=True, auto_registration=True):
-        self.__config = None
         self.__flows_client = None
         self.__tools = None
+        self.public_config = gladier.config.GladierConfig(self.config_filename, self.section)
+        self.private_config = gladier.config.GladierSecretsConfig(self.secret_config_filename,
+                                                                  self.section, self.client_id)
         self.authorizers = authorizers or dict()
         self.auto_login = auto_login
         self.auto_registration = auto_registration
@@ -84,27 +86,6 @@ class GladierBaseClient(object):
         return gladier.version.__version__
 
     @property
-    def config(self):
-        """
-        Get the Gladier Config, set by ``self.config_filename``
-
-        :return: The current local Gladier config, configparser.ConfigParser
-        """
-        if self.__config is not None:
-            return self.__config
-        self.__config = gladier.config.GladierConfig(filename=self.config_filename)
-        return self.__config
-
-    @property
-    def gconfig(self):
-        """
-        Each Gladier Client has its own section in the local Gladier Config.
-
-        :return: the current config section (self.section) for this Gladier client
-        """
-        return self.config[self.section]
-
-    @property
     def section(self):
         """Get the default section name for the config. The section name is derived
         from the name of the user's flow_definition class turned snake case."""
@@ -112,10 +93,6 @@ class GladierBaseClient(object):
         # https://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-snake-case
         snake_name = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
         snake_name = re.sub('([a-z0-9])([A-Z])', r'\1_\2', snake_name).lower()
-
-        if snake_name not in self.config.sections():
-            log.debug(f'Adding new section {snake_name}')
-            self.config[snake_name] = {}
         return snake_name
 
     @property
@@ -135,6 +112,17 @@ class GladierBaseClient(object):
         self.__tools = [self.get_gladier_defaults_cls(gt) for gt in self.gladier_tools]
         return self.__tools
 
+    def get_cfg(self, private=True):
+        cfg = self.private_config if private is True else self.public_config
+        section = self.section
+        if section not in cfg.sections():
+            log.debug(f'Adding new section {section} to {cfg.filename}')
+            cfg[section] = {}
+        return cfg
+
+    def get_section(self, private=True):
+        return self.get_cfg(private=private)[self.section]
+
     def get_native_client(self):
         """
         fair_research_login.NativeClient is used when ``authorizers`` are not provided to __init__.
@@ -148,12 +136,9 @@ class GladierBaseClient(object):
                 'Gladier client must be instantiated with a '
                 '"client_id" to use "login()!'
             )
-        secrets_cfg = fair_research_login.ConfigParserTokenStorage(
-            filename=self.secret_config_filename
-        )
         return fair_research_login.NativeClient(client_id=self.client_id,
                                                 app_name=self.app_name,
-                                                token_storage=secrets_cfg)
+                                                token_storage=self.get_cfg(private=True))
 
     @property
     def scopes(self):
@@ -169,7 +154,7 @@ class GladierBaseClient(object):
         # Set to funcx_scope = FuncXClient.FUNCX_SCOPE in funcx==0.0.6
         gladier_scopes.append('https://auth.globus.org/scopes/'
                               'facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/all')
-        flow_scope = self.config[self.section].get('flow_scope')
+        flow_scope = self.get_section(private=True).get('flow_scope')
         if flow_scope:
             gladier_scopes.append(flow_scope)
         return gladier_scopes
@@ -191,9 +176,8 @@ class GladierBaseClient(object):
         automate_authorizer = self.authorizers[
             globus_automate_client.flows_client.MANAGE_FLOWS_SCOPE
         ]
-        flow_authorizer = None
-        if self.gconfig.get('flow_scope'):
-            flow_authorizer = self.authorizers.get(self.gconfig['flow_scope'])
+        flow_scope = self.get_section(private=True).get('flow_scope')
+        flow_authorizer = self.authorizers.get(flow_scope)
 
         def get_flow_authorizer(*args, **kwargs):
             return flow_authorizer
@@ -224,9 +208,10 @@ class GladierBaseClient(object):
         if self.is_logged_in():
             log.debug('Already logged in, skipping login.')
             return
-        log.info("Initiating Native App Login...")
-        log.debug(f"Requesting Scopes: {self.scopes}")
-        login_kwargs["requested_scopes"] = login_kwargs.get("requested_scopes", self.scopes)
+        log.info('Initiating Native App Login...')
+        log.debug(f'Requesting Scopes: {self.scopes}')
+        login_kwargs['requested_scopes'] = login_kwargs.get('requested_scopes', self.scopes)
+        login_kwargs['refresh_tokens'] = login_kwargs.get('refresh_tokens', True)
         nc.login(**login_kwargs)
         self.authorizers = nc.get_authorizers_by_scope()
 
@@ -328,28 +313,30 @@ class GladierBaseClient(object):
                     f'Attribute "funcx_functions" on {tool} needs to be an iterable! Found '
                     f'{type(funcx_funcs)}')
 
+            cfgs = self.get_section(private=True)
+
             for func in funcx_funcs:
                 fid_name = self.get_funcx_function_name(func)
                 checksum = self.get_funcx_function_checksum(func)
                 checksum_name = self.get_funcx_function_checksum_name(func)
                 try:
-                    if not self.gconfig.get(fid_name):
+                    if not cfgs.get(fid_name):
                         raise gladier.exc.RegistrationException(
                             f'Tool {tool} missing funcx registration for {fid_name}')
-                    if not self.gconfig.get(checksum_name):
+                    if not cfgs.get(checksum_name):
                         raise gladier.exc.RegistrationException(
                             f'Tool {tool} with function {fid_name} '
                             f'has a function id but no checksum!')
-                    if not self.gconfig[checksum_name] == checksum:
+                    if not cfgs[checksum_name] == checksum:
                         raise gladier.exc.FunctionObsolete(
                             f'Tool {tool} with function {fid_name} '
                             f'has changed and needs to be re-registered.')
-                    funcx_ids[fid_name] = self.gconfig[fid_name]
+                    funcx_ids[fid_name] = cfgs[fid_name]
                 except (gladier.exc.RegistrationException, gladier.exc.FunctionObsolete):
                     if self.auto_registration is True:
                         log.info(f'Registering function {fid_name}')
                         self.register_funcx_function(func)
-                        funcx_ids[fid_name] = self.gconfig[fid_name]
+                        funcx_ids[fid_name] = cfgs[fid_name]
                     else:
                         raise
         return funcx_ids
@@ -358,9 +345,11 @@ class GladierBaseClient(object):
         """Register the functions with funcx. Ids are saved in the local gladier.cfg"""
         fxid_name = self.get_funcx_function_name(function)
         fxck_name = self.get_funcx_function_checksum_name(function)
-        self.gconfig[fxid_name] = self.funcx_client.register_function(function, function.__doc__)
-        self.gconfig[fxck_name] = self.get_funcx_function_checksum(function)
-        self.config.save()
+        cfg = self.get_cfg(private=True)
+        cfg[self.section][fxid_name] = self.funcx_client.register_function(function,
+                                                                           function.__doc__)
+        cfg[self.section][fxck_name] = self.get_funcx_function_checksum(function)
+        cfg.save()
 
     def get_flow_id(self):
         """Get the current flow id for the current Gladier flow definiton.
@@ -370,19 +359,19 @@ class GladierBaseClient(object):
         :raises: gladier.exc.FlowObsolete
         :raises: gladier.exc.NoFlowRegistered
         """
-        flow_id, flow_scope = self.gconfig.get('flow_id'), self.gconfig.get('flow_scope')
+        cfg_sec = self.get_section(private=True)
+        flow_id, flow_scope = cfg_sec.get('flow_id'), cfg_sec.get('flow_scope')
         if not flow_id or not flow_scope:
             if self.auto_registration is False:
                 raise gladier.exc.NoFlowRegistered(
-                    f'No flow registered for {self.config_filename} under section {self.gsection}')
+                    f'No flow registered for {self.config_filename} under section {self.section}')
             flow_id = self.register_flow()
-        elif self.gconfig.get('flow_checksum') != self.get_flow_checksum():
+        elif cfg_sec.get('flow_checksum') != self.get_flow_checksum():
             if self.auto_registration is False:
                 raise gladier.exc.FlowObsolete(
                     f'"flow_definition" on {self} has changed and needs to be re-registered.')
             self.register_flow()
-            flow_id = self.gconfig['flow_id']
-        return flow_id
+        return cfg_sec['flow_id']
 
     def register_flow(self):
         """
@@ -392,14 +381,16 @@ class GladierBaseClient(object):
         :raises: Automate exceptions on flow deployment.
         :return: an automate flow UUID
         """
-        flow_id = self.gconfig.get('flow_id')
+        cfg = self.get_cfg()
+
+        flow_id = cfg[self.section].get('flow_id')
         flow_definition = self.get_flow_definition()
         if flow_id:
             try:
                 log.info(f'Flow checksum failed, updating flow {flow_id}...')
                 self.flows_client.update_flow(flow_id, flow_definition)
-                self.gconfig['flow_checksum'] = self.get_flow_checksum()
-                self.config.save()
+                cfg[self.section]['flow_checksum'] = self.get_flow_checksum()
+                cfg.save()
             except globus_sdk.exc.GlobusAPIError as gapie:
                 if gapie.code == 'Not Found':
                     flow_id = None
@@ -409,11 +400,11 @@ class GladierBaseClient(object):
             log.info('No flow detected, deploying new flow...')
             title = f'{self.__class__.__name__} Flow'
             flow = self.flows_client.deploy_flow(flow_definition, title=title).data
-            self.gconfig['flow_id'] = flow['id']
-            self.gconfig['flow_scope'] = flow['globus_auth_scope']
-            self.gconfig['flow_checksum'] = self.get_flow_checksum()
-            self.config.save()
-            flow_id = self.gconfig['flow_id']
+            cfg[self.section]['flow_id'] = flow['id']
+            cfg[self.section]['flow_scope'] = flow['globus_auth_scope']
+            cfg[self.section]['flow_checksum'] = self.get_flow_checksum()
+            cfg.save()
+            flow_id = cfg[self.section]['flow_id']
         return flow_id
 
     def get_input(self):
@@ -438,10 +429,17 @@ class GladierBaseClient(object):
             #                 raise gladier.exc.ConfigException(
             #                   f'Conflict: Tools {tool} and {prev_tool} 'both define {r}')
             flow_input.update(tool.flow_input)
-            config_values = {k: self.gconfig[k] for k in tool.flow_input.keys()
-                             if k in self.gconfig}
-            if config_values:
-                log.info(f'{tool}: Loaded from local config {config_values}')
+            # Iterate over both private and public input variables, and include any relevant ones
+            # Note: Precedence starts and ends with: Public --> Private --> Default on Tool
+            t_input, t_required = set(tool.flow_input), set(getattr(tool, 'required_input', []))
+            input_keys = t_input.union(t_required)
+            log.debug(f'{tool}: Looking for overrides for the following input keys: {input_keys}')
+            for cfg in (self.get_cfg(private=True), self.get_cfg(private=False)):
+                override_values = {k: cfg[self.section][k] for k in input_keys
+                                   if cfg[self.section].get(k)}
+                if override_values:
+                    log.info(f'Updates from {cfg.filename}: {list(override_values.keys())}')
+                    flow_input.update(override_values)
         return {'input': flow_input}
 
     def check_input(self, tool, flow_input):
@@ -505,9 +503,10 @@ class GladierBaseClient(object):
             else:
                 raise gladier.exc.AuthException(
                     f'Need {self.missing_authorizers} to run flow!', self.missing_authorizers)
-        flow = self.flows_client.run_flow(flow_id, self.gconfig['flow_scope'],
+        cfg_sec = self.get_section(private=True)
+        flow = self.flows_client.run_flow(flow_id, cfg_sec['flow_scope'],
                                           combine_flow_input).data
-        log.info(f'Started flow {self.section} flow id "{self.gconfig["flow_id"]}" with action '
+        log.info(f'Started flow {self.section} flow id "{cfg_sec["flow_id"]}" with action '
                  f'"{flow["action_id"]}"')
         if flow['status'] == 'FAILED':
             raise gladier.exc.ConfigException(f'Flow Failed: {flow["details"]["description"]}')
@@ -524,9 +523,9 @@ class GladierBaseClient(object):
         :returns: a Globus Automate status object (with varying state structures)
         """
         try:
-            status = self.flows_client.flow_action_status(self.get_flow_id(),
-                                                          self.gconfig['flow_scope'],
-                                                          action_id).data
+            status = self.flows_client.flow_action_status(
+                self.get_flow_id(), self.get_section(private=True)['flow_scope'], action_id
+            ).data
         except KeyError:
             raise gladier.exc.ConfigException('No Flow defined, register a flow')
 

--- a/gladier/config.py
+++ b/gladier/config.py
@@ -1,5 +1,8 @@
 import logging
+import os
+import stat
 import configparser
+from fair_research_login.token_storage import flat_pack, flat_unpack
 
 log = logging.getLogger(__name__)
 
@@ -16,3 +19,34 @@ class GladierConfig(configparser.ConfigParser):
         with open(self.filename, 'w') as configfile:
             self.write(configfile)
             log.debug(f'Saved local gladier config to {configfile}')
+
+
+class GladierSecretsConfig(GladierConfig):
+
+    DEFAULT_PERMISSION = stat.S_IRUSR | stat.S_IWUSR
+    TOKENS_SECTION_DEFAULT = 'tokens_{client_id}'
+
+    def __init__(self, filename, section, client_id):
+        super().__init__(filename, section)
+        self.tokens_section = self.TOKENS_SECTION_DEFAULT.format(client_id=client_id)
+        if self.tokens_section not in self.sections():
+            log.debug(f'Adding new section {section} to {self.filename}')
+            self[self.tokens_section] = {}
+            self.save()
+
+    def save(self):
+        super().save()
+        os.chmod(self.filename, self.DEFAULT_PERMISSION)
+
+    def write_tokens(self, tokens):
+        for name, value in flat_pack(tokens).items():
+            self.set(self.tokens_section, name, value)
+        self.save()
+
+    def read_tokens(self):
+        return flat_unpack(dict(self.items(self.tokens_section)))
+
+    def clear_tokens(self):
+        self.remove_section(self.tokens_section)
+        self.add_section(self.tokens_section)
+        self.save()

--- a/gladier/tests/conftest.py
+++ b/gladier/tests/conftest.py
@@ -1,6 +1,5 @@
 from unittest.mock import Mock, PropertyMock
 import pytest
-import uuid
 import fair_research_login
 import globus_sdk
 
@@ -35,11 +34,11 @@ def mock_flows_client(monkeypatch, globus_response):
     """Ensure there are no calls out to the Globus Automate Client"""
     mock_flows_cli = Mock()
     mock_flows_cli.deploy_flow.return_value = globus_response(mock_data={
-        'id': str(uuid.uuid4()),
+        'id': 'mock_flow_id',
         'globus_auth_scope': mock_automate_flow_scope,
     })
     mock_flows_cli.run_flow.return_value = globus_response(mock_data={
-        'action_id': str(uuid.uuid4()),
+        'action_id': 'mock_flow_id',
         'status': 'ACTIVE',
     })
     monkeypatch.setattr(GladierBaseClient, 'flows_client',
@@ -51,7 +50,7 @@ def mock_flows_client(monkeypatch, globus_response):
 def mock_funcx_client(monkeypatch):
     """Ensure there are no calls out to the Funcx Client"""
     mock_fx_cli = Mock()
-    mock_fx_cli.register_function.return_value = str(uuid.uuid4())
+    mock_fx_cli.register_function.return_value = 'mock_funcx_id'
     monkeypatch.setattr(GladierBaseClient, 'funcx_client',
                         PropertyMock(return_value=mock_fx_cli))
     return mock_fx_cli

--- a/gladier/tests/conftest.py
+++ b/gladier/tests/conftest.py
@@ -25,6 +25,12 @@ def mock_config(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def mock_secrets_config(monkeypatch):
+    monkeypatch.setattr(config.GladierSecretsConfig, 'save', Mock())
+    return config.GladierSecretsConfig
+
+
+@pytest.fixture(autouse=True)
 def mock_flows_client(monkeypatch, globus_response):
     """Ensure there are no calls out to the Globus Automate Client"""
     mock_flows_cli = Mock()

--- a/gladier/tests/test_client_flows.py
+++ b/gladier/tests/test_client_flows.py
@@ -2,9 +2,42 @@ import pytest
 from gladier.tests.test_data.gladier_mocks import MockGladierClient
 
 
-@pytest.mark.skip
-def test_get_input():
-    pass
+def test_get_input(logged_in):
+    assert MockGladierClient().get_input() == {'input': {
+        'funcx_endpoint_non_compute': 'my_non_compute_endpoint_uuid',
+        'mock_func_funcx_id': 'mock_funcx_id',
+    }}
+
+
+def test_get_input_from_priv_config(logged_in, mock_secrets_config):
+    cli = MockGladierClient()
+    cli.get_cfg(private=True)[cli.section]['funcx_endpoint_non_compute'] = 'new_ep_uuid'
+    assert cli.get_input() == {'input': {
+        'funcx_endpoint_non_compute': 'new_ep_uuid',
+        'mock_func_funcx_id': 'mock_funcx_id',
+        }
+    }
+
+
+def test_get_input_from_pub_config(logged_in, mock_config):
+    cli = MockGladierClient()
+    cli.get_cfg(private=False)[cli.section]['funcx_endpoint_non_compute'] = 'new_ep_uuid'
+    assert cli.get_input() == {'input': {
+        'funcx_endpoint_non_compute': 'new_ep_uuid',
+        'mock_func_funcx_id': 'mock_funcx_id',
+        }
+    }
+
+
+def test_pub_config_overrides_priv(logged_in, mock_config, mock_secrets_config):
+    cli = MockGladierClient()
+    cli.get_cfg(private=True)[cli.section]['funcx_endpoint_non_compute'] = 'priv_ep_uuid'
+    cli.get_cfg(private=False)[cli.section]['funcx_endpoint_non_compute'] = 'pub_ep_uuid'
+    assert cli.get_input() == {'input': {
+        'funcx_endpoint_non_compute': 'pub_ep_uuid',
+        'mock_func_funcx_id': 'mock_funcx_id',
+        }
+    }
 
 
 def test_run_flow(logged_in):


### PR DESCRIPTION
Previously, unsharable flow_ids and funcx ids were stored in the
gladier.cfg, which typically resides in the working directory where
the client exists. This has all been moved to the 'secrets' config.

Note: This also changes the location in the config where secrets are
stored so they will match up to client_ids. This will break all
previous logins, requiring re-auth by the user. Old credentials will
need to be purged manually by the user.