### PR TITLE
fix: Tools with more than two states would raise error with flow gen

### DIFF
--- a/gladier/tests/test_client_flow_generation.py
+++ b/gladier/tests/test_client_flow_generation.py
@@ -61,3 +61,18 @@ def test_client_combine_gen_and_non_gen_flows(logged_in):
     flow_def = mc.flow_definition
     validate_flow_definition(flow_def)
     assert len(flow_def['States']) == 2
+
+
+def test_client_tool_with_three_steps(logged_in):
+
+    @generate_flow_definition
+    class MyClient(GladierBaseClient):
+        """My very cool Client"""
+        gladier_tools = [
+            'gladier.tests.test_data.gladier_mocks.MockToolThreeStates',
+        ]
+
+    mc = MyClient()
+    flow_def = mc.flow_definition
+    validate_flow_definition(flow_def)
+    assert len(flow_def['States']) == 3

--- a/gladier/tests/test_data/gladier_mocks.py
+++ b/gladier/tests/test_data/gladier_mocks.py
@@ -52,6 +52,60 @@ class MockTool(GladierBaseTool):
     ]
 
 
+class MockToolThreeStates(GladierBaseTool):
+
+    flow_definition = {
+        'Comment': 'Do three things. Not two. Not four.',
+        'StartAt': 'StateOne',
+        'States': {
+            'StateOne': {
+                'Comment': 'Do the first thing',
+                'Type': 'Action',
+                'ActionUrl': 'https://api.funcx.org/automate',
+                'ActionScope': 'https://auth.globus.org/scopes/funcx/automate2',
+                'ExceptionOnActionFailure': False,
+                'Parameters': {
+                    'tasks': [{
+                        'endpoint.$': '$.input.funcx_endpoint_non_compute',
+                        'func.$': '$.input.hello_world_funcx_id',
+                        'payload.$': '$.input.good_input',
+                    }]
+                },
+                'ResultPath': '$.PublishGatherMetadata',
+                'WaitTime': 60,
+                'Next': 'StateTwo',
+            },
+            'StateTwo': {
+                'Comment': 'Do the second thing',
+                'Type': 'Action',
+                'ActionUrl': 'https://actions.automate.globus.org/transfer/transfer',
+                'InputPath': '$.StateOne.details.result.foo',
+                'ResultPath': '$.StateTwo',
+                'WaitTime': 600,
+                'Next': 'StateThree',
+            },
+            'StateThree': {
+                'Comment': 'Do the third thing',
+                'Type': 'Action',
+                'ActionUrl': 'https://actions.globus.org/search/ingest',
+                'ExceptionOnActionFailure': False,
+                'InputPath': '$.StateOne.details.result.bar',
+                'ResultPath': '$.StateThree',
+                'WaitTime': 300,
+                'End': True
+            },
+        }
+    }
+
+    required_input = [
+        'funcx_endpoint_non_compute'
+    ]
+
+    flow_input = {
+        'funcx_endpoint_non_compute': 'my_non_compute_endpoint_uuid'
+    }
+
+
 class MockGladierClient(GladierBaseClient):
     secret_config_filename = 'gladier-secrets.cfg'
     config_filename = 'gladier.cfg'

--- a/gladier/utils/flow_generation.py
+++ b/gladier/utils/flow_generation.py
@@ -111,7 +111,7 @@ def get_ordered_flow_states(flow_definition):
         ordered_states[state] = flow_def['States'][state]
         if flow_def['States'][state].get('Next'):
             state = flow_def['States'][state].get('Next')
-        if flow_def['States'][state].get('End') is True:
+        elif flow_def['States'][state].get('End') is True:
             break
         else:
             raise FlowGenException(f'Flow definition has no "Next" or "End" for state "{state}" '


### PR DESCRIPTION
Sometimes, two character typos are enough to break everything.