### PR TITLE
Funcx upgrade

### DIFF
--- a/gladier/__init__.py
+++ b/gladier/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from gladier.client import GladierBaseClient
 from gladier.base import GladierBaseTool
 from gladier.decorators import generate_flow_definition
@@ -7,3 +8,12 @@ __all__ = [GladierBaseClient, GladierBaseTool, generate_flow_definition]
 
 # https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library  # noqa
 logging.getLogger("gladier").addHandler(logging.NullHandler())
+
+# This warning can be removed after: https://github.com/funcx-faas/funcX/pull/507
+try:
+    import funcx_endpoint
+    vinfo = sys.version_info
+    if vinfo.major == 3 and vinfo.minor > 7 and sys.platform in ['darwin']:
+        print('Recommend users downgrade to python 3.7 when using funcx-endpoint.')
+except ImportError:
+    pass

--- a/gladier/utils/flow_generation.py
+++ b/gladier/utils/flow_generation.py
@@ -86,15 +86,15 @@ def generate_funcx_flow_state(funcx_function):
     state_name = get_funcx_flow_state_name(funcx_function)
     tasks = [OrderedDict([
         ('endpoint.$', '$.input.funcx_endpoint_compute'),
-        ('func.$', f'$.input.{get_funcx_function_name(funcx_function)}'),
+        ('function.$', f'$.input.{get_funcx_function_name(funcx_function)}'),
         ('payload.$', '$.input'),
     ])]
     flow_state = OrderedDict([
         ('Comment', funcx_function.__doc__),
         ('Type', 'Action'),
-        ('ActionUrl', 'https://api.funcx.org/automate'),
+        ('ActionUrl', 'https://automate.funcx.org'),
         ('ActionScope', 'https://auth.globus.org/scopes/'
-                        'facd7ccc-c5f4-42aa-916b-a0e270e2c2a9/automate2'),
+                        'b3db7e59-a6f1-4947-95c2-59d6b7a70f8c/action_all'),
         ('ExceptionOnActionFailure', False),
         ('Parameters', OrderedDict(tasks=tasks)),
         ('ResultPath', f'$.{state_name}'),

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-funcx==0.0.5
-funcx-endpoint==0.0.3
+funcx>=0.2.3
 globus-automate-client>=0.10.6


### PR DESCRIPTION
Funcx 0.0.5 also depended on funcx-endpoint 0.0.3. funcx-endpoint
can be dropped in the next release, since adding it to gladier was
a convenience to ensure users didn't use the incompatible 0.2.3
package instead.

BREAKING CHANGE -- This will break all current funcx functions without
modification. Everyone will need to upgrade to the new funcX endpoint
package wherever they are executing functions. If manually generating
flow definitions, the following changes need to be made:

    'ActionUrl': 'https://automate.funcx.org',
    'ActionScope': 'https://auth.globus.org/scopes/b3db7e59-a6f1-4947-95c2-59d6b7a70f8c/action_all'

Additionally for funcx payloads the following

    'func.$': '$.input.'

Needs to be changed to:

    'function.$': '$.input.'