### PR TITLE
fix: logout not properly clearing authorizers cache

### DIFF
--- a/gladier/client.py
+++ b/gladier/client.py
@@ -282,6 +282,8 @@ class GladierBaseClient(object):
                                             '"client_id" to use "login()!')
         log.info(f'Revoking the following scopes: {self.scopes}')
         self.get_native_client().logout()
+        # Clear authorizers cache
+        self.authorizers = dict()
 
     def is_logged_in(self):
         """

--- a/gladier/tests/test_client_auth.py
+++ b/gladier/tests/test_client_auth.py
@@ -16,3 +16,10 @@ def test_logged_in(logged_in):
 def test_scopes(logged_in):
     cli = MockGladierClient()
     assert not set(ALL_FLOW_SCOPES).difference(cli.scopes)
+
+
+def test_authorizers_cleared_after_logout(logged_in):
+    cli = MockGladierClient()
+    assert cli.authorizers
+    cli.logout()
+    assert cli.authorizers == dict()


### PR DESCRIPTION
This previously resulted in:
my_cli.login()
my_cli.logout()
my_cli.is_logged_in()  # Would still be true

This should now be fixed.

#111 