### PR TITLE
docs: Fix Gladier Tools docstrings

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 sphinx
 sphinx-rtd-theme
-gladier
 m2r2
+gladier
+git+https://github.com/globus-gladier/gladier-tools.git#egg=gladier-tools


### PR DESCRIPTION
Docstrings were not showing up due to the gladier-tools package not
being installed on the read-the-docs site. This adds the latest on
main so changes will immediately show up. We could set this back to
use the latest stable version in the future, but I think it will be
handy to see the latest changes immediately instead of waiting for a
stable release.