### PR TITLE
docs: Added defaults to tar example, slight tweaks

### DIFF
--- a/docs/examples/tar_and_transfer.py
+++ b/docs/examples/tar_and_transfer.py
@@ -13,21 +13,30 @@ class TarAndTransfer(GladierBaseClient):
 if __name__ == '__main__':
     flow_input = {
         'input': {
-            'tar_input': '',
+            # The directory below should exist with files. It will be archived by the Tar Tool.
+            'tar_input': '~/myfiles',
             # Set this to your own funcx endpoint where you want to tar files
-            'funcx_endpoint_compute': '',
+            # 'funcx_endpoint_compute': '',
             # Set this to the globus endpoint where your tarred archive has been created
-            'transfer_source_endpoint_id': '',
+            # 'transfer_source_endpoint_id': '',
             # By default, this will transfer the tar file to Globus Tutorial Endpoint 1
             'transfer_destination_endpoint_id': 'ddb59aef-6d04-11e5-ba46-22000b92c6ec',
-            'transfer_source_path': '',
-            'transfer_destination_path': '',
+            # By default, the Tar Tool will append '.tgz' to the archive it creates
+            'transfer_source_path': '~/myfiles.tgz',
+            'transfer_destination_path': '~/my_archives/myfiles.tgz',
             'transfer_recursive': False,
         }
     }
-    tat = TarAndTransfer()
-    pprint(tat.flow_definition)
-    flow = tat.run_flow(flow_input=flow_input)
+    # Instantiate the client
+    tar_and_transfer = TarAndTransfer()
+
+    # Optionally, print the flow definition
+    # pprint(tar_and_transfer.flow_definition)
+
+    # Run the flow
+    flow = tar_and_transfer.run_flow(flow_input=flow_input)
+
+    # Track the progress
     action_id = flow['action_id']
-    tat.progress(action_id)
-    pprint(tat.get_status(action_id))
+    tar_and_transfer.progress(action_id)
+    pprint(tar_and_transfer.get_status(action_id))


### PR DESCRIPTION
Commented out 'funcx_endpoint_compute' so Gladier will catch the missing
value and complain. This will ensure the user sets that value. Otherwise,
the flow will start and result in a "FlowFailed". Useful, since people
tend to run things 'as is' and are confused by any errors which are not
extremely specific.