### PR TITLE
fix: Flow Modifier errors not propagating Client or Tool names

### DIFF
--- a/gladier/client.py
+++ b/gladier/client.py
@@ -642,8 +642,8 @@ class GladierBaseClient(object):
             else:
                 raise
 
-        log.info(f'Started flow {flow_kwargs.get("label")} flow id "{cfg_sec["flow_id"]}" with action '
-                 f'"{flow["action_id"]}"')
+        log.info(f'Started flow "{cfg_sec["flow_id"]}" labeled {flow_kwargs.get("label")} '
+                 f'with action "{flow["action_id"]}"')
 
         if flow['status'] == 'FAILED':
             raise gladier.exc.ConfigException(f'Flow Failed: {flow["details"]["description"]}')

--- a/gladier/utils/flow_generation.py
+++ b/gladier/utils/flow_generation.py
@@ -22,7 +22,7 @@ def combine_tool_flows(client: GladierBaseClient, modifiers):
 
     Modifiers can be applied to any of the states within the flow.
     """
-    flow_moder = FlowModifiers(client.tools, modifiers)
+    flow_moder = FlowModifiers(client.tools, modifiers, cls=client)
 
     flow_states = OrderedDict()
     for tool in client.tools:
@@ -42,7 +42,7 @@ def generate_tool_flow(tool: GladierBaseTool, modifiers):
     """Generate a flow definition for a Gladier Tool based on the defined ``funcx_functions``.
     Accepts modifiers for funcx functions"""
 
-    flow_moder = FlowModifiers([tool], modifiers)
+    flow_moder = FlowModifiers([tool], modifiers, cls=tool)
 
     flow_states = OrderedDict()
     for fx_func in tool.funcx_functions:


### PR DESCRIPTION
When an invalid flow modifier is set, Gladier will list the original
Tool or Client which isn't configured correctly