### PR TITLE
Only save config on migrate when migration needed

### DIFF
--- a/gladier/client.py
+++ b/gladier/client.py
@@ -76,13 +76,15 @@ class GladierBaseClient(object):
         self.auto_registration = auto_registration
 
         private_cfg = self.get_cfg(private=True)
-        private_cfg = gladier.utils.config_migrations.migrate_gladier(private_cfg)
-        private_cfg.save()
+        if gladier.utils.config_migrations.needs_migration(private_cfg):
+            private_cfg = gladier.utils.config_migrations.migrate_gladier(private_cfg)
+            private_cfg.save()
 
         if os.path.exists(self.config_filename):
             pub_cfg = self.get_cfg(private=False)
-            pub_cfg = gladier.utils.config_migrations.migrate_gladier(pub_cfg)
-            pub_cfg.save()
+            if gladier.utils.config_migrations.needs_migration(pub_cfg):
+                pub_cfg = gladier.utils.config_migrations.migrate_gladier(pub_cfg)
+                pub_cfg.save()
 
         if self.authorizers and self.auto_login:
             log.warning('Authorizers provided when "auto_login=True", you probably want to set '

--- a/gladier/tests/test_migrations.py
+++ b/gladier/tests/test_migrations.py
@@ -24,3 +24,12 @@ def test_migrate_to_v03x(mock_config, logged_in, mock_version_030):
     mock_config['mock_gladier_client']['myfuncx_funcx_id'] = 'uuid'
     mc = MockGladierClient()
     assert mc.get_cfg()['general']['version'] == mock_version_030
+
+
+def test_no_migration_needed(mock_config, logged_in):
+    """Ensure the config isn't written when no migrations are needed.
+    This can corrupt the tokens file if the client is written rapidly."""
+    mock_config['general'] = {}
+    mock_config['general']['version'] = __version__
+    MockGladierClient()
+    assert not mock_config.save.called

--- a/gladier/utils/config_migrations.py
+++ b/gladier/utils/config_migrations.py
@@ -106,14 +106,20 @@ class FuncX005Downgrade(ConfigMigration):
         panic_print(self.message.format(context=ctx))
 
 
+MIGRATIONS = [
+    AddVersionToConfig,
+    FuncX024Upgrade,
+    FuncX005Downgrade,
+    UpdateConfigVersion,
+]
+
+
+def needs_migration(config):
+    return any(m(config).is_applicable() for m in MIGRATIONS)
+
+
 def migrate_gladier(config):
-    migrations = [
-        AddVersionToConfig,
-        FuncX024Upgrade,
-        FuncX005Downgrade,
-        UpdateConfigVersion,
-    ]
-    for migration in migrations:
+    for migration in MIGRATIONS:
         m_instance = migration(config)
         if m_instance.is_applicable():
             log.info(f'Applying migration: {m_instance.__class__.__name__}')


### PR DESCRIPTION
Only apply migrations when the config needs to be updated. This fixes the config getting corrupted when rapidly written to by many processes. 