### PR TITLE
chore: Update dependencies, add fair-research-login

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 funcx<0.4.0>=0.3.6
-globus-automate-client<0.14>=0.13
+globus-automate-client<0.15.0>=0.13
 packaging>=21.3
+fair-research-login>=0.2.6


### PR DESCRIPTION
Fair-research-login was implicitly added via funcx. FuncX will likely
remove this dependency later on, and Gladier will need to continue using
it.