### PR TITLE
Removes the docstring during registration

### DIFF
--- a/gladier/client.py
+++ b/gladier/client.py
@@ -432,8 +432,7 @@ class GladierBaseClient(object):
         fxid_name = gladier.utils.name_generation.get_funcx_function_name(function)
         fxck_name = gladier.utils.name_generation.get_funcx_function_checksum_name(function)
         cfg = self.get_cfg(private=True)
-        cfg[self.section][fxid_name] = self.funcx_client.register_function(function,
-                                                                           function.__doc__)
+        cfg[self.section][fxid_name] = self.funcx_client.register_function(function)
         cfg[self.section][fxck_name] = self.get_funcx_function_checksum(function)
         cfg.save()
 


### PR DESCRIPTION
This removes the docstring from the function registration step. When the docstring is too long (>10…24 characters) it causes an issue with registration as we place the description in a 1024 length varchar field. I'll raise this on the funcx side, but this is a fix for failed registration.