### PR TITLE
fix: Aliases not working with tools that use @generate_flow_definition

### DIFF
--- a/gladier/decorators.py
+++ b/gladier/decorators.py
@@ -34,7 +34,7 @@ def generate_flow_definition(_cls=None, *, modifiers=None):
         @functools.wraps(cls)
         def wrapper(*args, **kwargs):
             if issubclass(cls, GladierBaseTool):
-                c = cls()
+                c = cls(*args, **kwargs)
                 c.flow_definition = generate_tool_flow(c, modifiers)
                 return c
             elif issubclass(cls, GladierBaseClient):

--- a/gladier/tests/test_data/gladier_mocks.py
+++ b/gladier/tests/test_data/gladier_mocks.py
@@ -1,4 +1,5 @@
 from gladier import GladierBaseTool, GladierBaseClient
+from gladier.decorators import generate_flow_definition
 
 # Roughly simulates the look of a Globus Automate flow scope
 mock_automate_flow_scope = ('https://auth.globus.org/scopes/mock_tool_flow_scope/'
@@ -50,6 +51,11 @@ class MockTool(GladierBaseTool):
     funcx_functions = [
         mock_func,
     ]
+
+
+@generate_flow_definition
+class GeneratedTool(GladierBaseTool):
+    funcx_functions = [mock_func]
 
 
 class MockToolWithRequirements(GladierBaseTool):

--- a/gladier/utils/tool_chain.py
+++ b/gladier/utils/tool_chain.py
@@ -39,6 +39,7 @@ class ToolChain:
         unique_flow_states = OrderedDict()
         for state_name, state_data in self.get_ordered_flow_states(tool.flow_definition).items():
             if tool.alias:
+                log.debug(f'Renaming state {state_name} to use alias {tool.alias}')
                 state_name, state_data = tool.rename_state(state_name, state_data)
             unique_flow_states[state_name] = state_data
         log.debug(f'Complete flow states: {list(unique_flow_states.keys())}')


### PR DESCRIPTION
Fixed a problem where if @generate_flow_definition was used to
define a flow definition for a Tool, aliases wouldn't be applied
properly.

This was due to the decorator simply not passing args to the instances
it created.

Fix for #181 