### PR TITLE
Fix regression caused by login manager refactor

### DIFF
--- a/gladier/storage/config.py
+++ b/gladier/storage/config.py
@@ -11,10 +11,13 @@ class GladierConfig(configparser.ConfigParser):
         super().__init__()
         self.section = section
         self.filename = filename
+        self.load()
+
+    def load(self):
         self.read(self.filename)
-        if section not in self.sections():
-            log.debug(f'Section {section} missing, adding to config.')
-            self[section] = {}
+        if self.section not in self.sections():
+            log.debug(f'Section {self.section} missing, adding to config.')
+            self[self.section] = {}
             self.save()
 
     def save(self):
@@ -29,10 +32,12 @@ class GladierConfig(configparser.ConfigParser):
 
     def get_value(self, name: str) -> str:
         try:
+            self.load()
             return self.get(self.section, name)
         except configparser.NoOptionError:
             return None
 
     def set_value(self, name: str, value: str):
+        self.load()
         self.set(self.section, name, value)
         self.save()

--- a/gladier/storage/tokens.py
+++ b/gladier/storage/tokens.py
@@ -13,14 +13,17 @@ class GladierSecretsConfig(GladierConfig):
         os.chmod(self.filename, self.DEFAULT_PERMISSION)
 
     def write_tokens(self, tokens):
+        self.load()
         for name, value in flat_pack(tokens).items():
             self.set(self.section, name, value)
         self.save()
 
     def read_tokens(self):
+        self.load()
         return flat_unpack(dict(self.items(self.section)))
 
     def clear_tokens(self):
+        self.load()
         self.remove_section(self.section)
         self.add_section(self.section)
         self.save()


### PR DESCRIPTION
The split of using the login manager as a separate configurable entity #192 means we now have two instances of config files writing to the same file. It was possible for the two configs to become out of sync with one another, and overwrite values with older versions. These changes ensure fresh configs are loaded any time there are changes so this can't happen.

Long term, I think we'll want to split these configs into separate files. Token storage will live in its own file with strict POSIX permissions, while general config (flow/funcx ids and checksums) will occupy a separate file. This will allow token storage and general storage to both be customized as needed.