### PR TITLE
Fix first time flow use

### DIFF
--- a/gladier/managers/funcx_manager.py
+++ b/gladier/managers/funcx_manager.py
@@ -33,7 +33,7 @@ class FuncXManager:
             return self.__funcx_client
 
         funcx_login_manager = gladier.utils.funcx_login_manager.FuncXLoginManager(
-            authorizers=self.login_manager.get_authorizers()
+            authorizers=self.login_manager.get_manager_authorizers()
         )
 
         self.__funcx_client = FuncXClient(login_manager=funcx_login_manager)


### PR DESCRIPTION
FuncX functions would not be registered on first time use due to authorizers possibly not being set. A request for the funcx client now triggers login if needed, and calls to register_function cannot be done without a live client.