### PR TITLE
docs: Fix images not showing up on RTD

### DIFF
--- a/docs/gladier/overview.rst
+++ b/docs/gladier/overview.rst
@@ -25,7 +25,7 @@ You can read more about Gladier, including example applications, in a
 `technical report <https://arxiv.org/pdf/2204.05128.pdf>`_; here we
 focus on how to install and use it, and provide pointers to sample code.
 
-.. figure:: static/001-Overview-Globus-Automation-Services.png
+.. figure:: https://media.githubusercontent.com/media/globus-gladier/gladier/main/docs/gladier/static/001-Overview-Globus-Automation-Services.png
    :scale: 50 %
    :alt: Globus Automation Services
 

--- a/docs/gladier/setup.rst
+++ b/docs/gladier/setup.rst
@@ -11,7 +11,7 @@ comprises two steps:
 * Transfer: Copy data to the analysis computer.
 * Compute: Run the analysis function on the data copied in the first step.
 
-.. figure:: static/002-Setup-Transfer-Compute.jpeg
+.. figure:: https://media.githubusercontent.com/media/globus-gladier/gladier/main/docs/gladier/static/002-Setup-Transfer-Compute.jpeg
    :scale: 25 %
    :alt: Globus Automation Services
 


### PR DESCRIPTION
RTD doesn't work so well with pulling down binary files tracked with Git LFS. Ideally it could pull images as needed and access them locally without any additional steps. The problem is RTD build machines don't have git lfs clients, and most git lfs clients appear to authorize to github repos via SSH. 

A much simpler solution here is to access lfs files through Github's media servers instead. They are accessible locally and via RTD. A downside is adding new files, but it's better than checking them in directly and keeps all of our glaider-related stuff in one repo.