### PR TITLE
fix: Multiple instantiations of a Gladier Client raising errors

### DIFF
--- a/gladier/tests/test_client_flow_generation.py
+++ b/gladier/tests/test_client_flow_generation.py
@@ -228,3 +228,38 @@ def test_choice_state_tool_chaining(logged_in):
     # Chain should add 'next' in transition state 1b
     assert 'Next' in flow_def['States']['1b']
     assert flow_def['States']['1b']['Next'] == 'MockFunc'
+
+
+def test_flow_generation_edge_case(logged_in):
+
+    class MyTool(GladierBaseTool):
+        flow_definition = {
+            'StartAt': '1',
+            'States': {
+                '1': {'Type': 'Action', 'End': True},
+            }
+        }
+
+    class MyTool2(GladierBaseTool):
+        flow_definition = {
+            'StartAt': '2',
+            'States': {
+                '2': {'Type': 'Action', 'End': True},
+            }
+        }
+
+    @generate_flow_definition
+    class MyFuncXState(GladierBaseTool):
+        funcx_functions = [lambda x: x]
+
+    @generate_flow_definition
+    class MyClient(GladierBaseClient):
+        gladier_tools = [
+            MyTool,
+            MyTool2,
+            MyFuncXState,
+        ]
+    MyClient()
+    assert 'End' in MyTool.flow_definition['States']["1"].keys()
+    assert 'End' in MyTool2.flow_definition['States']["2"].keys()
+    MyClient()

--- a/gladier/utils/tool_chain.py
+++ b/gladier/utils/tool_chain.py
@@ -68,7 +68,7 @@ class ToolChain:
             self._flow_definition['StartAt'] = new_flow['StartAt']
             return
 
-        self._flow_definition['States'].update(new_flow['States'])
+        self._flow_definition['States'].update(copy.deepcopy(new_flow['States']))
         for t_state in transition_states:
             self.add_transition(t_state, new_flow['StartAt'])
 


### PR DESCRIPTION
An issue with the ToolChain class caused it to re-use references to internal state within tool's flow definition, causing improper updates to tool flow definition dataq.