### PR TITLE
fix: flow generation bug when using multiple funcx functions on a tool

### DIFF
--- a/gladier/tests/test_client_flow_generation.py
+++ b/gladier/tests/test_client_flow_generation.py
@@ -230,6 +230,35 @@ def test_choice_state_tool_chaining(logged_in):
     assert flow_def['States']['1b']['Next'] == 'MockFunc'
 
 
+def test_chaining_cycle_flow_raises_error(logged_in):
+
+    class MyTool(GladierBaseTool):
+        flow_definition = {
+            'StartAt': '1A',
+            'States': {
+                '1A': {
+                    'Type': 'Pass',
+                    'Next': '2A',
+                },
+                '2A': {
+                    'Type': 'Pass',
+                    'Next': '1A',
+                },
+            }
+        }
+
+    @generate_flow_definition
+    class MyClient(GladierBaseClient):
+        """Example Docs"""
+        gladier_tools = [
+            MyTool,
+            'gladier.tests.test_data.gladier_mocks.MockTool',
+        ]
+
+    with pytest.raises(exc.FlowGenException):
+        MyClient()
+
+
 def test_flow_generation_edge_case(logged_in):
 
     class MyTool(GladierBaseTool):

--- a/gladier/tests/test_flow_traversal.py
+++ b/gladier/tests/test_flow_traversal.py
@@ -170,3 +170,20 @@ def test_state_does_not_exist():
     }
     with pytest.raises(FlowGenException):
         list(get_end_states(flow))
+
+
+def test_flow_with_cycle():
+    flow = {
+        'StartAt': '1A',
+        'States': {
+            '1A': {
+                'Type': 'Pass',
+                'Next': '2A',
+            },
+            '2A': {
+                'Type': 'Pass',
+                'Next': '1A',
+            },
+        }
+    }
+    assert list(get_end_states(flow)) == []

--- a/gladier/tests/test_tool_flow_generation.py
+++ b/gladier/tests/test_tool_flow_generation.py
@@ -49,6 +49,16 @@ def test_tool_generate_multiple_states():
     assert fd['States']['MockFunc2']['End'] is True
 
 
+def test_tool_duplicate_funcx_functions():
+
+    @generate_flow_definition
+    class MockTool(GladierBaseTool):
+        funcx_functions = [mock_func, mock_func]
+
+    with pytest.raises(FlowGenException):
+        MockTool()
+
+
 def test_tool_generate_no_states():
 
     @generate_flow_definition

--- a/gladier/tests/test_tool_flow_generation.py
+++ b/gladier/tests/test_tool_flow_generation.py
@@ -45,6 +45,8 @@ def test_tool_generate_multiple_states():
     assert fd['StartAt'] == 'MockFunc'
     assert len(fd['States']) == 2
     assert set(fd['States']) == {'MockFunc', 'MockFunc2'}
+    assert fd['States']['MockFunc']['Next'] == 'MockFunc2'
+    assert fd['States']['MockFunc2']['End'] is True
 
 
 def test_tool_generate_no_states():

--- a/gladier/utils/flow_generation.py
+++ b/gladier/utils/flow_generation.py
@@ -1,4 +1,5 @@
 import logging
+import typing
 from gladier.base import GladierBaseTool
 from gladier.client import GladierBaseClient
 from gladier.exc import FlowGenException
@@ -25,9 +26,19 @@ def combine_tool_flows(client: GladierBaseClient, modifiers):
     return flow_moder.apply_modifiers(chain.flow_definition)
 
 
+def _get_duplicate_functions(funcx_functions: typing.List[callable]):
+    tracked_set = set()
+    func_names = [get_funcx_flow_state_name(f) for f in funcx_functions]
+    return [f for f in func_names if f in tracked_set or tracked_set.add(f)]
+
+
 def generate_tool_flow(tool: GladierBaseTool, modifiers):
     """Generate a flow definition for a Gladier Tool based on the defined ``funcx_functions``.
     Accepts modifiers for funcx functions"""
+    duplicate_functions = _get_duplicate_functions(tool.funcx_functions)
+    if duplicate_functions:
+        raise FlowGenException(f'Tool {tool} contains duplicate function names: '
+                               f'{duplicate_functions}')
 
     flow_moder = FlowModifiers([tool], modifiers, cls=tool)
 


### PR DESCRIPTION
Multiple FuncX Functions defined on a tool resulted in an improperly chained flow, causing the second function to not execute.