### PR TITLE
fix: erroneously removed `get_flow_id()` method on Gladier Clients

### DIFF
--- a/docs/gladier/sdk_reference/gladier.rst
+++ b/docs/gladier/sdk_reference/gladier.rst
@@ -5,6 +5,6 @@ Gladier Base Client
 
 
 .. autoclass:: gladier.client.GladierBaseClient
-   :members: login, logout, get_input, run_flow, progress, get_status
+   :members: login, logout, get_input, run_flow, progress, get_status, get_flow_id
    :member-order: bysource
    :show-inheritance:

--- a/gladier/client.py
+++ b/gladier/client.py
@@ -298,6 +298,12 @@ class GladierBaseClient(object):
                 funcx_ids[name] = val
         return funcx_ids
 
+    def get_flow_id(self) -> str:
+        """
+        Get the flow id from the flows manager class.
+        """
+        return self.flows_manager.get_flow_id()
+
     def get_input(self) -> dict:
         """
         Get funcx function ids, funcx endpoints, and each tool's default input. Default

--- a/gladier/tests/test_client.py
+++ b/gladier/tests/test_client.py
@@ -1,4 +1,5 @@
 from gladier.tests.test_data.gladier_mocks import MockGladierClient
+from gladier.managers import FlowsManager
 
 
 def test_get_input(logged_in):
@@ -6,6 +7,10 @@ def test_get_input(logged_in):
         'funcx_endpoint_non_compute': 'my_non_compute_endpoint_uuid',
         'mock_func_funcx_id': 'mock_funcx_id',
     }}
+
+
+def test_get_flow_id(logged_in):
+    assert MockGladierClient().get_flow_id() is None
 
 
 def test_get_input_from_aliased_tool(logged_in):

--- a/gladier/tests/test_flows_manager.py
+++ b/gladier/tests/test_flows_manager.py
@@ -65,6 +65,15 @@ def test_custom_scope_id(logged_out):
     assert scope in cli.login_manager.missing_authorizers
 
 
+def test_custom_scope_id():
+    fm = FlowsManager(flow_id='foo')
+    cli = MockGladierClient(flows_manager=fm)
+    assert cli.flows_manager == fm
+    assert fm.flow_id == 'foo'
+    assert fm.get_flow_id() == 'foo'
+    assert cli.get_flow_id() == 'foo'
+
+
 def test_dependent_scope_change_run_flow(auto_login, mock_flows_client,
                                          mock_dependent_token_change_error,
                                          monkeypatch):


### PR DESCRIPTION
Method was removed with the new FlowManager class, which now handles deployment of the flow. The re-added method calls get_flow_id() on the manager class.