### PR TITLE
fix: CallbackLoginManager not being a top-level import

### DIFF
--- a/gladier/__init__.py
+++ b/gladier/__init__.py
@@ -2,9 +2,12 @@ import logging
 from gladier.client import GladierBaseClient
 from gladier.base import GladierBaseTool
 from gladier.decorators import generate_flow_definition
-from gladier.managers import FlowsManager
+from gladier.managers import FlowsManager, CallbackLoginManager
 
-__all__ = [GladierBaseClient, GladierBaseTool, generate_flow_definition, FlowsManager]
+__all__ = [
+    GladierBaseClient, GladierBaseTool, generate_flow_definition, FlowsManager,
+    CallbackLoginManager
+]
 
 # https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library  # noqa
 logging.getLogger("gladier").addHandler(logging.NullHandler())


### PR DESCRIPTION
CallbackLoginManager was a feature in 0.8.0 and documented here: https://gladier.readthedocs.io/en/latest/gladier/custom_auth.html

The top level import has been fixed so that the custom script now works as expected.