### PR TITLE
fix: State modifiers being given incorrect values for some items

### DIFF
--- a/gladier/tests/test_tool_flow_generation.py
+++ b/gladier/tests/test_tool_flow_generation.py
@@ -157,3 +157,17 @@ def test_tool_modifier_custom_name_payloads():
     fd = tool.flow_definition
     fx_task = fd['States']['MockFunc2']['Parameters']['tasks'][0]
     assert fx_task['payload.$'] == '$.MyStuff.details.results'
+
+
+def test_tool_custom_action_url():
+    @generate_flow_definition(modifiers={
+        'mock_func': {
+            'ActionUrl': 'https://myap.example.com',
+        }
+    })
+    class MockTool(GladierBaseTool):
+        funcx_functions = [mock_func]
+
+    tool = MockTool()
+    assert tool.flow_definition['States']['MockFunc']['ActionUrl'] == \
+        'https://myap.example.com'

--- a/gladier/utils/flow_modifiers.py
+++ b/gladier/utils/flow_modifiers.py
@@ -102,7 +102,7 @@ class FlowModifiers:
                 mod_value = self.get_state_result_path(sn)
             elif mod_value in self.state_names:
                 mod_value = self.get_state_result_path(mod_value)
-            else:
+            elif mod_name not in state_modifiers:
                 mod_value = f'$.input.{mod_value}'
 
         # Remove duplicate keys
@@ -112,7 +112,7 @@ class FlowModifiers:
 
         # Note: Top level State types don't end with '.$', all others must end with
         # '.$' to indicate the value should be replaced. '.=' is not supported or possible yet
-        if isinstance(mod_value, str) and mod_value.startswith('$.') and mod_name not in state_modifiers:
+        if isinstance(mod_value, str) and mod_value.startswith('$.'):
             mod_name = f'{mod_name}.$'
         item[mod_name] = mod_value
         log.debug(f'Set modifier {mod_name} to {mod_value}')


### PR DESCRIPTION
Modifying "ActionUrl" would result in $.input.myvalue.

This has been fixed.