### PR TITLE
Confidential Client Support

### DIFF
--- a/gladier/client.py
+++ b/gladier/client.py
@@ -133,6 +133,7 @@ class GladierBaseClient(object):
             self.flows_manager.flow_title = f'{self.__class__.__name__} flow'
 
         self.compute_manager = ComputeManager(auto_registration=auto_registration)
+        self.storage.update()
 
         for man in (self.flows_manager, self.compute_manager):
             man.set_storage(self.storage, replace=False)

--- a/gladier/managers/login_manager.py
+++ b/gladier/managers/login_manager.py
@@ -191,7 +191,6 @@ class ConfidentialClientLoginManager(BaseLoginManager):
 
     def get_authorizers(self) -> Mapping[str, Union[AccessTokenAuthorizer, RefreshTokenAuthorizer]]:
         tokens = self.storage.read_tokens()
-        print(tokens.keys())
         if not tokens:
             log.info('Tokens failed to load, no tokens in storage.')
             return dict()

--- a/gladier/storage/tokens.py
+++ b/gladier/storage/tokens.py
@@ -1,29 +1,45 @@
 import os
 import stat
+import logging
 from fair_research_login.token_storage import flat_pack, flat_unpack
 from gladier.storage.config import GladierConfig
+
+
+log = logging.getLogger(__name__)
 
 
 class GladierSecretsConfig(GladierConfig):
 
     DEFAULT_PERMISSION = stat.S_IRUSR | stat.S_IWUSR
 
+    def __init__(self, *args, tokens_section='tokens', **kwargs):
+        self.tokens_section = tokens_section
+        super().__init__(*args, **kwargs)
+
     def save(self):
         super().save()
         os.chmod(self.filename, self.DEFAULT_PERMISSION)
 
+    def load(self):
+        super().load()
+        if self.tokens_section not in self.sections():
+            self[self.tokens_section] = {}
+            self.save()
+
     def write_tokens(self, tokens):
         self.load()
         for name, value in flat_pack(tokens).items():
-            self.set(self.section, name, value)
+            self.set(self.tokens_section, name, value)
+        log.debug(f'Wrote tokens to {self.filename}')
         self.save()
 
     def read_tokens(self):
         self.load()
-        return flat_unpack(dict(self.items(self.section)))
+        return flat_unpack(dict(self.items(self.tokens_section)))
 
     def clear_tokens(self):
         self.load()
-        self.remove_section(self.section)
-        self.add_section(self.section)
+        self.remove_section(self.tokens_section)
+        self.add_section(self.tokens_section)
+        log.debug(f'Tokens cleared from {self.filename}')
         self.save()

--- a/gladier/tests/test_client_auth.py
+++ b/gladier/tests/test_client_auth.py
@@ -4,7 +4,7 @@ from gladier.tests.test_data.gladier_mocks import MockGladierClient
 
 
 def test_logged_out(logged_out):
-    assert MockGladierClient(auto_login=False).is_logged_in() is False
+    assert MockGladierClient().is_logged_in() is False
 
 
 def test_logged_in(logged_in):

--- a/gladier/tests/test_flows_manager.py
+++ b/gladier/tests/test_flows_manager.py
@@ -98,7 +98,7 @@ def test_dependent_scope_change_run_flow(auto_login, mock_flows_client,
 
 def test_dependent_scope_change_no_login(logged_in, mock_flows_client,
                                          monkeypatch):
-    cli = MockGladierClient(auto_login=False)
+    cli = MockGladierClient()
     cli.login_manager.login = Mock()
     cli.login_manager.add_scope_change(['foo'])
 


### PR DESCRIPTION
Users can specify client credentials inside their python environment, and Gladier will automatically create a new config file, separate from the user config file, and store all credentials and cached ids there. Specifying credentials looks like this:

```
export GLADIER_CLIENT_ID=my-client-id
export GLADIER_CLIENT_SECRET=my-client-secret
```

These changes also move ~/.gladier-secrets.cfg into `~/.gladier/` where each file is named according to the CLIENT_ID. This is either the confidential client id used, or the native id used (Whether built-in or custom). Migration code exists to move them into place for any older clients. 