### PR TITLE
Fix legacy functions

### DIFF
--- a/gladier/client.py
+++ b/gladier/client.py
@@ -359,7 +359,9 @@ class GladierBaseClient(object):
         compute_ids = dict()
         for tool in self.tools:
             log.debug(f'Checking functions for {tool}')
-            compute_funcs = getattr(tool, 'compute_functions', [])
+            compute_funcs = (
+                getattr(tool, 'compute_functions', []) + getattr(tool, 'funcx_functions', [])
+            )
             if not compute_funcs:
                 log.warning(f'Tool {tool} did not define any compute functions!')
             if not compute_funcs and not isinstance(compute_funcs, Iterable):

--- a/gladier/utils/flow_modifiers.py
+++ b/gladier/utils/flow_modifiers.py
@@ -30,7 +30,10 @@ class FlowModifiers:
     def __init__(self, tools, modifiers, cls=None):
         self.cls = cls
         self.tools = tools
-        self.functions = [func for tool in tools for func in tool.compute_functions]
+        self.functions = (
+            [func for tool in tools for func in tool.compute_functions] +
+            [func for tool in tools for func in getattr(tool, 'funcx_functions', [])]
+        )
         self.function_names = [f.__name__ for f in self.functions]
         self.state_names = [get_compute_flow_state_name(f) for f in self.functions]
         self.modifiers = modifiers


### PR DESCRIPTION
Using modifiers for old tools will no longer be allowed, and will
require tools to be updated to use the new compute function syntax. Requiring upgrades
fixes a problem where attempting to use modifiers will work, but cause a mismatch in inputs
causing unexpected failures when running flows. Instead of making this fully backwards compatible,
it's easier to just make people upgrade or downgrade to the correct versions.

For example, flows will need to be defined with the following:

```
'tasks': [{
    'endpoint.$': '$.input.compute_endpoint',
    'function.$': f'$.input.my_function_name_function_id',
    'payload.$': '$.input',
}]
```

And all tools will need to define "compute_endpoints" and
"compute_functions" instead of "funcx_endpoint_compute/funcx_endpoint_non_compute"
and "my_function_name_funcx_id".

More info in the migration guide.