### PR TITLE
fix: Function serialization failures using compute-sdk 2.2.3

### DIFF
--- a/gladier/managers/compute_manager.py
+++ b/gladier/managers/compute_manager.py
@@ -31,7 +31,10 @@ class ComputeManager(ServiceManager):
             authorizers=self.login_manager.get_manager_authorizers()
         )
 
-        self.__compute_client = Client(login_manager=compute_login_manager)
+        self.__compute_client = Client(
+            code_serialization_strategy=serialize.DillCodeSource(),
+            login_manager=compute_login_manager
+    )
         return self.__compute_client
 
     @staticmethod
@@ -51,7 +54,7 @@ class ComputeManager(ServiceManager):
         Get the SHA256 checksum of a compute function
         :return: sha256 hex string of a given compute function
         """
-        fxs = serialize.ComputeSerializer()
+        fxs = serialize.ComputeSerializer(strategy_code=serialize.DillCodeSource())
         serialized_func = fxs.serialize(compute_function).encode()
         return hashlib.sha256(serialized_func).hexdigest()
 


### PR DESCRIPTION
2.2.x switched to DillCode serialization instead of DillCodeSource by defalut, which caused functions run on 2.2.x to fail when using functions within Gladier Tools:

https://github.com/funcx-faas/funcX/blob/main/compute_sdk/globus_compute_sdk/serialize/concretes.py#L121

Switching to DillCodeSource manually fixes this, at least for now. There are nasty tradeoffs, such as potentially not being able to use functions within notebooks.

#254 