### PR TITLE
refactor!: Remove Globus-Automate-Client dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,8 @@ sphinx
 sphinx-rtd-theme
 m2r2
 gladier
+# Temporary fix for https://github.com/yaml/pyyaml/issues/724
+PyYAML==5.3.1
 git+https://github.com/globus-gladier/gladier-tools.git#egg=gladier-tools
 
 

--- a/gladier/client.py
+++ b/gladier/client.py
@@ -388,7 +388,7 @@ class GladierBaseClient(object):
             self.check_input(tool, combine_flow_input)
 
         self.sync_flow()
-        return self.flows_manager.run_flow(flow_input=combine_flow_input, **flow_kwargs)
+        return self.flows_manager.run_flow(body=combine_flow_input, **flow_kwargs)
 
     def get_compute_function_ids(self):
         """Get all compute function ids for this run, registering them if there are no ids

--- a/gladier/tests/test_client_auth.py
+++ b/gladier/tests/test_client_auth.py
@@ -1,6 +1,13 @@
-from globus_automate_client.flows_client import ALL_FLOW_SCOPES
-
+import globus_sdk
 from gladier.tests.test_data.gladier_mocks import MockGladierClient
+
+ALL_FLOW_SCOPES = [
+    globus_sdk.FlowsClient.scopes.manage_flows,
+    globus_sdk.FlowsClient.scopes.view_flows,
+    globus_sdk.FlowsClient.scopes.run,
+    globus_sdk.FlowsClient.scopes.run_status,
+    globus_sdk.FlowsClient.scopes.run_manage,
+]
 
 
 def test_logged_out(logged_out):

--- a/gladier/tests/test_client_flow_generation.py
+++ b/gladier/tests/test_client_flow_generation.py
@@ -1,6 +1,5 @@
 import pytest
 from gladier import GladierBaseClient, GladierBaseTool, generate_flow_definition, exc
-from globus_automate_client.flows_client import validate_flow_definition
 from gladier.utils.tool_alias import StateSuffixVariablePrefix
 
 
@@ -61,7 +60,6 @@ def test_client_combine_gen_and_non_gen_flows(logged_in):
 
     mc = MyClient()
     flow_def = mc.flow_definition
-    validate_flow_definition(flow_def)
     assert len(flow_def["States"]) == 2
 
 
@@ -76,7 +74,6 @@ def test_client_tool_with_three_steps(logged_in):
 
     mc = MyClient()
     flow_def = mc.flow_definition
-    validate_flow_definition(flow_def)
     assert len(flow_def["States"]) == 3
 
 
@@ -107,7 +104,6 @@ def test_client_tool_duplication(logged_in):
 
     mc = MyClient()
     flow_def = mc.flow_definition
-    validate_flow_definition(flow_def)
     assert len(flow_def["States"]) == 3
     assert set(flow_def["States"]) == {
         "MockFunc",
@@ -132,7 +128,6 @@ def test_client_tool_duplication_with_generated_defs(logged_in):
 
     mc = MyClient()
     flow_def = mc.flow_definition
-    validate_flow_definition(flow_def)
     assert len(flow_def["States"]) == 2
     assert set(flow_def["States"]) == {"SortedFirst", "SortedSecond"}
 
@@ -149,7 +144,6 @@ def test_client_tool_duplication_with_generated_def_strs(logged_in):
 
     mc = MyClient()
     flow_def = mc.flow_definition
-    validate_flow_definition(flow_def)
     assert len(flow_def["States"]) == 2
     assert set(flow_def["States"]) == {"MockFuncFirst", "MockFuncSecond"}
 
@@ -167,7 +161,6 @@ def test_client_tool_complex_duplication(logged_in):
 
     mc = MyClient()
     flow_def = mc.flow_definition
-    validate_flow_definition(flow_def)
     assert len(flow_def["States"]) == 9
     assert set(flow_def["States"]) == {
         "StateOne",
@@ -229,7 +222,6 @@ def test_choice_state_tool_chaining(logged_in):
 
     mc = MyClient()
     flow_def = mc.flow_definition
-    validate_flow_definition(flow_def)
     assert len(flow_def["States"]) == 4
     assert flow_def["States"]["MockFunc"].get("Next") is None
     # Chain should add 'next' in transition state 1b

--- a/gladier/tests/test_tool_flow_generation.py
+++ b/gladier/tests/test_tool_flow_generation.py
@@ -3,7 +3,6 @@ from gladier.base import GladierBaseTool
 from gladier.decorators import generate_flow_definition
 from gladier.exc import FlowGenException, FlowModifierException
 from gladier import GladierBaseClient
-from globus_automate_client.flows_client import validate_flow_definition
 
 
 def mock_func(data):
@@ -24,7 +23,6 @@ def test_tool_generate_basic_flow_no_mods():
 
     tool = MockTool()
     fd = tool.flow_definition
-    validate_flow_definition(fd)
     assert isinstance(fd, dict)
     assert fd["Comment"] == "Flow with states: MockFunc"
     assert fd["StartAt"] == "MockFunc"
@@ -39,7 +37,6 @@ def test_tool_generate_multiple_states():
 
     tool = MockTool()
     fd = tool.flow_definition
-    validate_flow_definition(fd)
     assert isinstance(fd, dict)
     assert fd["Comment"] == "Flow with states: MockFunc, MockFunc2"
     assert fd["StartAt"] == "MockFunc"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+globus-sdk>=3.23.0,<4
 globus-compute-sdk>=2.0.1,<3.0.0
-globus-automate-client>=0.13,<0.17
 packaging>=21.3
 fair-research-login>=0.2.6
 pydantic>=1.0


### PR DESCRIPTION
Remove the globus-automate-client dependency in favor of calling into the base globus-sdk instead