### PR TITLE
Fix Exception from improperly parsing the globus-sdk scope change error

### DIFF
--- a/gladier/managers/flows_manager.py
+++ b/gladier/managers/flows_manager.py
@@ -278,15 +278,15 @@ class FlowsManager(ServiceManager):
         flow_id = self.get_flow_id()
         flow_checksum = self.storage.get_value("flow_checksum")
         if not flow_id:
-            raise gladier.exc.NoFlowRegistered(
-                "No flow_id set on flow manager and no id tracked in storage."
-            )
+            message = "No flow_id set on flow manager and no id tracked in storage."
+            log.info(message)
+            raise gladier.exc.NoFlowRegistered(message)
         elif flow_checksum != self.get_flow_checksum(
             self.flow_definition, self.flow_schema
         ):
-            raise gladier.exc.FlowObsolete(
-                f'"flow_definition" on {self} has changed and needs to be re-registered.'
-            )
+            message = f'"flow_definition" on {self} has changed and needs to be re-registered.'
+            log.info(message)
+            raise gladier.exc.FlowObsolete(message)
 
     def sync_flow(self) -> str:
         """

--- a/gladier/tests/conftest.py
+++ b/gladier/tests/conftest.py
@@ -154,7 +154,8 @@ def mock_globus_api_error(monkeypatch):
     class MockGlobusAPIError(Exception):
         http_status = 400
         code = "Error"
-        message = json.dumps(
+        message = ""
+        text = json.dumps(
             {
                 "error": {
                     "code": "FLOW_GENERIC_ERROR",
@@ -179,7 +180,7 @@ def mock_dependent_token_change_error(mock_globus_api_error):
             }
         }
     )
-    mock_globus_api_error.message = automate_message
+    mock_globus_api_error.text = automate_message
     return mock_globus_api_error
 
 


### PR DESCRIPTION
When dependent scopes change on flows, Gladier now properly detects the change and initiates a new login.
