### PR TITLE
Add some missing imports to gladier.tools

### DIFF
--- a/docs/gladier/sdk_reference/state_api/builtins.rst
+++ b/docs/gladier/sdk_reference/state_api/builtins.rst
@@ -4,6 +4,38 @@ Builtins
 ========
 
 
+Action State
+------------
+
+.. autoclass:: gladier.tools.ActionState
+   :member-order: bysource
+   :show-inheritance:
+
+
+And Rule (for Choice)
+---------------------
+
+.. autoclass:: gladier.tools.AndRule
+   :member-order: bysource
+   :show-inheritance:
+
+
+Choice Option
+-------------
+
+.. autoclass:: gladier.tools.ChoiceOption
+   :member-order: bysource
+   :show-inheritance:
+
+
+Choice Rule
+-----------
+
+.. autoclass:: gladier.tools.ChoiceRule
+   :member-order: bysource
+   :show-inheritance:
+
+
 Choice State
 ------------
 
@@ -24,6 +56,22 @@ Fail State
 ----------
 
 .. autoclass:: gladier.tools.FailState
+   :member-order: bysource
+   :show-inheritance:
+
+
+Not Rule (for Choice)
+---------------------
+
+.. autoclass:: gladier.tools.NotRule
+   :member-order: bysource
+   :show-inheritance:
+
+
+Or Rule (for Choice)
+--------------------
+
+.. autoclass:: gladier.tools.OrRule
    :member-order: bysource
    :show-inheritance:
 

--- a/docs/gladier/sdk_reference/state_api/compute.rst
+++ b/docs/gladier/sdk_reference/state_api/compute.rst
@@ -2,6 +2,6 @@ Compute
 =======
 
 
-.. autoclass:: gladier.tools.ComputeState
+.. autoclass:: gladier.tools.Compute
    :member-order: bysource
    :show-inheritance:

--- a/gladier/tests/test_builtin_tools.py
+++ b/gladier/tests/test_builtin_tools.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 import pytest
 from pydantic import ValidationError
 
-from gladier.tools.builtins import (
+from gladier.tools import (
     ActionState,
     AndRule,
     ChoiceOption,

--- a/gladier/tools/__init__.py
+++ b/gladier/tools/__init__.py
@@ -2,35 +2,57 @@ from __future__ import annotations
 
 import typing as t
 
-from .helpers import exclusive_validator_generator, validate_path_property
-from .builtins import ChoiceState, ExpressionEvalState, FailState, WaitState, PassState
+from .builtins import (
+    ActionState,
+    AndRule,
+    ChoiceOption,
+    ChoiceRule,
+    ChoiceState,
+    ComparisonRule,
+    ExpressionEvalState,
+    FailState,
+    NotRule,
+    OrRule,
+    PassState,
+    WaitState,
+)
 from .globus import (
     Compute,
-    Transfer,
-    TransferItem,
-    TransferDelete,
-    SearchIngest,
+    ComputeFunctionType,
     SearchDelete,
     SearchDeleteByQuery,
+    SearchIngest,
+    Transfer,
+    TransferDelete,
+    TransferItem,
 )
+from .helpers import exclusive_validator_generator, validate_path_property
 
 _nameables = (
     x.__name__
     for x in (
-        exclusive_validator_generator,
-        validate_path_property,
+        ActionState,
+        AndRule,
+        ChoiceOption,
+        ChoiceRule,
         ChoiceState,
+        ComparisonRule,
         ExpressionEvalState,
         FailState,
-        WaitState,
+        NotRule,
+        OrRule,
         PassState,
+        WaitState,
         Compute,
-        TransferItem,
-        Transfer,
-        TransferDelete,
-        SearchIngest,
+        ComputeFunctionType,
         SearchDelete,
         SearchDeleteByQuery,
+        SearchIngest,
+        Transfer,
+        TransferDelete,
+        TransferItem,
+        exclusive_validator_generator,
+        validate_path_property,
     )
     if hasattr(x, "__name__")
 )

--- a/gladier/tools/builtins/choice_state.py
+++ b/gladier/tools/builtins/choice_state.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, validator
 from pydantic.fields import ModelField
 
 from gladier import BaseState, JSONObject
-from gladier.tools import exclusive_validator_generator, validate_path_property
+from gladier.tools.helpers import exclusive_validator_generator, validate_path_property
 
 
 class ChoiceRule(BaseModel):
@@ -161,8 +161,7 @@ class ChoiceState(BaseState):
 
     .. code-block:: python
 
-        from gladier.tools.builtins import ChoiceOption, ComparisonRule, FailState, PassState
-        from gladier.tools import ChoiceState
+        from gladier.tools import ChoiceState, ChoiceOption, ComparisonRule, FailState, PassState
         from gladier import GladierClient
 
 

--- a/gladier/tools/builtins/wait.py
+++ b/gladier/tools/builtins/wait.py
@@ -7,7 +7,7 @@ from pydantic import validator
 from pydantic.fields import ModelField
 
 from gladier import StateWithNextOrEnd, JSONObject
-from gladier.tools import exclusive_validator_generator
+from gladier.tools.helpers import exclusive_validator_generator
 
 _wait_state_exclusives_list = ["seconds", "timestamp", "seconds_path", "timestamp_path"]
 


### PR DESCRIPTION
Some of the support type classes from the globus and builtin sub-modules weren't popped up to the top level gladier.tools module so using them still required imports from the sub-modules. For consistency, seems better to include them at the gladier.tools level.