### PR TITLE
Composite State Updates

### DIFF
--- a/gladier/tools/builtins/__init__.py
+++ b/gladier/tools/builtins/__init__.py
@@ -11,6 +11,7 @@ from .choice_state import (
     ComparisonRule,
     NotRule,
     OrRule,
+    ChoiceSkipState,
 )
 from .expression_eval import ExpressionEvalState
 from .fail import FailState
@@ -29,6 +30,7 @@ _nameables = (
         ComparisonRule,
         NotRule,
         OrRule,
+        ChoiceSkipState,
         ExpressionEvalState,
         PassState,
         WaitState,


### PR DESCRIPTION
This adds some updates to how the composite states are handled. It changes the protocol for generating the flow definition. It supports setting a prefix on a composite state which is pre-pended to each state generated. To do this, the `get_flow_definition` implementation calls out to a separate method which generates the composite flow at the state model level rather than at the flow definition dict level.

This also specs the method of setting next on a composite state. There's more than can probably be done in this space, but it does seem to provide the minimum necessary functionality.

Also includes an example state for using Choice to optionally skip a state. This maybe shouldn't be in this package (e.g. in gladier-tools instead), but it does provide an example (and testable) of the use of BaseCompositeState within the main gladier package which probably makes sense to have in the main gladier package.