### PR TITLE
fix: Gladier progress status checking sometimes running too fast

### DIFF
--- a/gladier/client.py
+++ b/gladier/client.py
@@ -485,7 +485,7 @@ class GladierBaseClient(object):
         """
         return self.flows_manager.get_status(action_id)
 
-    def progress(self, action_id, callback=None):
+    def progress(self, action_id, callback=None, delay=2):
         """
         Continuously call self.get_status() until the flow completes. Each status response is
         used as a parameter to the provided callback, by default will use the builtin callback
@@ -496,7 +496,7 @@ class GladierBaseClient(object):
         :param callback: The function to call with the result from self.get_status. Must take
                          a single parameter: mycallback(self.get_status())
         """
-        return self.flows_manager.progress(action_id, callback=callback)
+        return self.flows_manager.progress(action_id, callback=callback, delay=delay)
 
     def get_details(self, action_id, state_name):
         """

--- a/gladier/managers/flows_manager.py
+++ b/gladier/managers/flows_manager.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import time
 import logging
 import warnings
 import typing as t
@@ -449,7 +450,7 @@ class FlowsManager(ServiceManager):
         if response["status"] == "ACTIVE":
             print(f'[{response["status"]}]: {response["details"]["description"]}')
 
-    def progress(self, run_id, callback=None):
+    def progress(self, run_id, callback=None, delay=2):
         """
         Continuously call self.get_status() until the flow completes. Each status response is
         used as a parameter to the provided callback, by default will use the builtin callback
@@ -465,6 +466,7 @@ class FlowsManager(ServiceManager):
         while status["status"] not in ["SUCCEEDED", "FAILED"]:
             status = self.get_status(run_id)
             callback(status)
+            time.sleep(delay)
 
     def get_details(self, run_id, state_name):
         """

--- a/gladier/tests/test_flows_manager.py
+++ b/gladier/tests/test_flows_manager.py
@@ -1,6 +1,7 @@
 import sys
 import uuid
 import pytest
+import time
 import globus_sdk
 from unittest.mock import Mock
 from gladier.exc import ConfigException
@@ -238,8 +239,13 @@ def test_get_status(
 
 
 def test_progress(
-    auto_login, mock_flow_status_active, mock_flow_status_succeeded, mock_flows_client
+    auto_login,
+    mock_flow_status_active,
+    mock_flow_status_succeeded,
+    mock_flows_client,
+    monkeypatch,
 ):
+    monkeypatch.setattr(time, "sleep", Mock())
     fm = FlowsManager(flow_id="foo", login_manager=auto_login)
 
     class GlobusResponse(object):


### PR DESCRIPTION
If progress runs for too long during a time of low load on the Flows service, it can sometimes return statuses fast enough that the service will run into the ping limit and begin to reject requests. This includes a small delay for each status ping to ensure this can't happen