### PR TITLE
fix: Exception when registering or updating flows

### DIFF
--- a/gladier/managers/flows_manager.py
+++ b/gladier/managers/flows_manager.py
@@ -135,13 +135,7 @@ class FlowsManager(ServiceManager):
 
     @property
     def flow_schema(self) -> dict:
-        return self._flow_schema or {
-            "input_schema": {
-                "additionalProperties": True,
-                "properties": {},
-                "type": "object",
-            }
-        }
+        return self._flow_schema or {"additionalProperties": True}
 
     @flow_schema.setter
     def flow_schema(self, value: dict):


### PR DESCRIPTION
When Gladier deployed or updated flows without schemas, there was a new error:

Additional properties are not allowed ('input' was unexpected)"

This was due to the default schema becoming invalid. This fixes that and allows schemas to be regitered with Gladier