### PR TITLE
feat: Compute functions now use globus_group on client for functions

### DIFF
--- a/gladier/client.py
+++ b/gladier/client.py
@@ -131,7 +131,9 @@ class GladierBaseClient(object):
         if not self.flows_manager.flow_title:
             self.flows_manager.flow_title = f"{self.__class__.__name__} flow"
 
-        self.compute_manager = ComputeManager(auto_registration=auto_registration)
+        self.compute_manager = ComputeManager(
+            auto_registration=auto_registration, group=self.globus_group
+        )
         self.storage.update()
 
         for man in (self.flows_manager, self.compute_manager):

--- a/gladier/managers/compute_manager.py
+++ b/gladier/managers/compute_manager.py
@@ -11,9 +11,10 @@ log = logging.getLogger(__name__)
 
 
 class ComputeManager(ServiceManager):
-    def __init__(self, auto_registration: bool = True, **kwargs):
+    def __init__(self, auto_registration: bool = True, group: str = None, **kwargs):
         super().__init__(**kwargs)
         self.auto_registration = auto_registration
+        self.group = group
 
     def get_scopes(self):
         return gladier.managers.compute_login_manager.ComputeLoginManager.SCOPES
@@ -126,5 +127,7 @@ class ComputeManager(ServiceManager):
 
     def register_function(self, tool: GladierBaseTool, function):
         """Register the functions with Globus Compute."""
-        log.info(f"{tool.__class__.__name__}: registering function {function.__name__}")
-        return self.compute_client.register_function(function)
+        log.info(
+            f"{tool.__class__.__name__}: registering function {function.__name__} with group {self.group}"
+        )
+        return self.compute_client.register_function(function, group=self.group)

--- a/gladier/tests/test_client.py
+++ b/gladier/tests/test_client.py
@@ -1,4 +1,5 @@
-from gladier.tests.test_data.gladier_mocks import MockGladierClient
+from unittest.mock import Mock
+from gladier.tests.test_data.gladier_mocks import MockGladierClient, mock_func
 
 
 def test_get_input(logged_in):
@@ -54,3 +55,17 @@ def test_pub_config_overrides_priv(logged_in, storage, mock_secrets_config):
 def test_run_flow(logged_in):
     cli = MockGladierClient()
     cli.run_flow()
+
+
+def test_propagated_group_uuid(monkeypatch, logged_in):
+    class MockGladierClientShared(MockGladierClient):
+        globus_group = "my-globus-group"
+
+        gladier_tools = ["gladier.tests.test_data.gladier_mocks.GeneratedTool"]
+
+    cli = MockGladierClientShared()
+    monkeypatch.setattr(cli.compute_manager.compute_client, "register_function", Mock())
+    cli.run_flow()
+    cli.compute_manager.compute_client.register_function.assert_called_with(
+        mock_func, group="my-globus-group"
+    )


### PR DESCRIPTION
If a globus_group was defined for a Gladier Client, those will be applied on function registration to defined functions