### PR TITLE
Custom compute manager

### DIFF
--- a/gladier/client.py
+++ b/gladier/client.py
@@ -116,6 +116,7 @@ class GladierBaseClient(object):
         auto_registration: bool = True,
         login_manager: t.Optional[BaseLoginManager] = None,
         flows_manager: t.Optional[FlowsManager] = None,
+        compute_manager: t.Optional[ComputeManager] = None,
     ):
         self._tools = None
         self.storage = self._determine_storage()
@@ -131,8 +132,8 @@ class GladierBaseClient(object):
         if not self.flows_manager.flow_title:
             self.flows_manager.flow_title = f"{self.__class__.__name__} flow"
 
-        self.compute_manager = ComputeManager(
-            auto_registration=auto_registration, group=self.globus_group
+        self.compute_manager = compute_manager or ComputeManager(
+            auto_registration=auto_registration
         )
         self.storage.update()
 

--- a/gladier/client.py
+++ b/gladier/client.py
@@ -135,7 +135,8 @@ class GladierBaseClient(object):
             self.flows_manager.flow_title = f"{self.__class__.__name__} flow"
 
         self.compute_manager = compute_manager or ComputeManager(
-            auto_registration=auto_registration
+            auto_registration=auto_registration,
+            group=self.globus_group,
         )
         self.storage.update()
 

--- a/gladier/client.py
+++ b/gladier/client.py
@@ -100,6 +100,8 @@ class GladierBaseClient(object):
                           will auto-login when additional scopes are needed.
     :param flows_manager: A flows manager class with customized behavior. Attrs like group
                           and login_manager will automatically be set if None
+    :param compute_manager: A compute manager class with customized behavior. EXPERIMENTAL.
+                            Will likely change in the future!
     :raises gladier.exc.AuthException: if authorizers given are insufficient
 
     """


### PR DESCRIPTION
Allow passing a custom compute manager into Gladier. This provides the capability to modify how internals of the compute manager behave, but does not yet document how users should do so. This will allow some prescriptive solutions until we figure out those details should properly behave. 