### PR TITLE
feat: Allow passing extended flow and run kw args

### DIFF
--- a/gladier/client.py
+++ b/gladier/client.py
@@ -112,6 +112,8 @@ class GladierBaseClient(object):
     subscription_id: t.Optional[str] = None
     globus_group: t.Optional[str] = None
     alias_class = gladier.utils.tool_alias.StateSuffixVariablePrefix
+    flow_kwargs = None
+    run_kwargs = None
 
     def __init__(
         self,

--- a/gladier/managers/flows_manager.py
+++ b/gladier/managers/flows_manager.py
@@ -59,6 +59,12 @@ class FlowsManager(ServiceManager):
                       flow, ``None`` takes no action and attempts to run "obselete" flows.
     :param redeploy_on_404: Deploy a new flow if attempting to run the current flow ID results
                             in 404. Behavior is disabled if an explicit flow_id is specified.
+    :param flow_kwargs: Any additional arguments passed to ``flows_client.create_flow`` or
+        ``flows_client.update_flow``. Supersedes any Gladier defaults, and will raise a warning
+        if any exist. For example, passing ``globus_group`` to this class and ``flow_administrators``
+        as a ``flow_kwargs`` will only result in the ``flows_kwargs`` arguments taking effect.
+    :param run_kwargs: Deploy a new flow if attempting to run the current flow ID results
+                            in 404. Behavior is disabled if an explicit flow_id is specified.
 
     When used with a Gladier Client, following items will be auto-configured and should not be
     set explicitly in the constructor:

--- a/gladier/tests/test_flows_manager.py
+++ b/gladier/tests/test_flows_manager.py
@@ -182,7 +182,7 @@ def test_run_flow_run_kwargs(auto_login, storage, mock_specific_flow_client):
     )
     fm.run_flow()
     assert mock_specific_flow_client.run_flow.called
-    assert mock_specific_flow_client.run_flow.called_with(foo="bar")
+    mock_specific_flow_client.run_flow.assert_called_with(foo="bar")
 
 
 def test_run_flow_run_kwargs_conflicting_args(
@@ -193,11 +193,13 @@ def test_run_flow_run_kwargs_conflicting_args(
         flow_id="foo",
         login_manager=auto_login,
         globus_group="mygroup",
-        run_kwargs={"run_managers": bob_id},
+        run_kwargs={"run_managers": [bob_id]},
     )
     fm.run_flow()
     assert mock_specific_flow_client.run_flow.called
-    assert mock_specific_flow_client.run_flow.called_with(run_managers=bob_id)
+    mock_specific_flow_client.run_flow.assert_called_with(
+        run_managers=[bob_id], run_monitors=["urn:globus:groups:id:mygroup"]
+    )
 
 
 def test_run_flow_redeploy_on_404(

--- a/gladier/tests/test_flows_manager.py
+++ b/gladier/tests/test_flows_manager.py
@@ -198,7 +198,6 @@ def test_run_flow_run_kwargs_conflicting_args(
     fm.run_flow()
     assert mock_specific_flow_client.run_flow.called
     assert mock_specific_flow_client.run_flow.called_with(run_managers=bob_id)
-    assert False
 
 
 def test_run_flow_redeploy_on_404(

--- a/gladier/tests/test_flows_manager.py
+++ b/gladier/tests/test_flows_manager.py
@@ -162,6 +162,45 @@ def test_schema_changed(auto_login, storage):
     assert fm.flow_changed() is True
 
 
+def test_flow_kwargs_changed(auto_login, storage):
+    fm = FlowsManager(
+        flow_id="foo", login_manager=auto_login, flow_definition={"foo": "bar"}
+    )
+    fm.storage = storage
+    fm.sync_flow()
+    assert fm.flow_changed() is False
+    fm.flow_kwargs = {"flow_managers": "foo@globus.org"}
+    assert fm.flow_changed() is True
+
+
+def test_run_flow_run_kwargs(auto_login, storage, mock_specific_flow_client):
+    fm = FlowsManager(
+        flow_id="foo",
+        login_manager=auto_login,
+        flow_definition={"foo": "bar"},
+        run_kwargs={"foo": "bar"},
+    )
+    fm.run_flow()
+    assert mock_specific_flow_client.run_flow.called
+    assert mock_specific_flow_client.run_flow.called_with(foo="bar")
+
+
+def test_run_flow_run_kwargs_conflicting_args(
+    auto_login, storage, mock_specific_flow_client
+):
+    bob_id = "urn:globus:auth:identity:bob@globus.org"
+    fm = FlowsManager(
+        flow_id="foo",
+        login_manager=auto_login,
+        globus_group="mygroup",
+        run_kwargs={"run_managers": bob_id},
+    )
+    fm.run_flow()
+    assert mock_specific_flow_client.run_flow.called
+    assert mock_specific_flow_client.run_flow.called_with(run_managers=bob_id)
+    assert False
+
+
 def test_run_flow_redeploy_on_404(
     auto_login,
     storage,


### PR DESCRIPTION
This feature allows for passing arguments into the flow update and flow run methods. Flow kwargs will also prompt an update to the existing flow definition.

Any argument passed directly to the flow manager will supersede any arguments present on the flow, and will raise warnings instead.