### PR TITLE
fix: MISSING SCOPE error when adding new AP to flow

### DIFF
--- a/gladier/tests/conftest.py
+++ b/gladier/tests/conftest.py
@@ -192,22 +192,6 @@ def mock_globus_api_error(monkeypatch):
 
 
 @pytest.fixture
-def mock_dependent_token_change_error(mock_globus_api_error):
-    # Dependent token change error happens when APs are added to a flow.
-    automate_message = json.dumps(
-        {
-            "error": {
-                "code": "FLOW_INPUT_ERROR",
-                "detail": "For RunAs value User, unable to get tokens for scopes "
-                "{'https://auth.globus.org/scopes/actions.globus.org/transfer/transfer'}",
-            }
-        }
-    )
-    mock_globus_api_error.text = automate_message
-    return mock_globus_api_error
-
-
-@pytest.fixture
 def mock_flow_status_active():
     return {
         "action_id": "c1171657-704c-4537-896f-fcd5bad9062e",

--- a/gladier/tests/test_flows_manager.py
+++ b/gladier/tests/test_flows_manager.py
@@ -102,10 +102,13 @@ def test_unexpected_400_run_flow_without_json(
 def test_dependent_scope_change_run_flow(
     auto_login,
     mock_specific_flow_client,
-    mock_dependent_token_change_error,
+    mock_globus_api_error,
     monkeypatch,
 ):
-    mock_specific_flow_client.run_flow.side_effect = mock_dependent_token_change_error
+    mock_globus_api_error.http_status = 403
+    mock_globus_api_error.code = "MISSING_SCOPE"
+
+    mock_specific_flow_client.run_flow.side_effect = mock_globus_api_error
     fm = FlowsManager(flow_id="foo", login_manager=auto_login)
     # Ensure scopes are set, then disable auto_login behavior
     auto_login.get_manager_authorizers()


### PR DESCRIPTION
When adding a new Action Provider to a flow between runs, Gladier now properly re-authorizes the flow