### PR TITLE
!Upgrade globus sdk, drop support for Globus SDK v3, and Globus Compute SDK v3

### DIFF
--- a/gladier/managers/__init__.py
+++ b/gladier/managers/__init__.py
@@ -1,6 +1,5 @@
 from .login_manager import (
     BaseLoginManager,
-    AutoLoginManager,
     CallbackLoginManager,
     UserAppLoginManager,
 )
@@ -9,7 +8,6 @@ from .compute_manager import ComputeManager
 
 __all__ = [
     "BaseLoginManager",
-    "AutoLoginManager",
     "CallbackLoginManager",
     "FlowsManager",
     "ComputeManager",

--- a/gladier/managers/compute_manager.py
+++ b/gladier/managers/compute_manager.py
@@ -7,8 +7,6 @@ import gladier
 from gladier.base import GladierBaseTool
 from gladier.managers.service_manager import ServiceManager
 from globus_compute_sdk import Client, serialize, version as compute_sdk_version
-from globus_compute_sdk.sdk.login_manager import AuthorizerLoginManager
-from globus_compute_sdk.sdk.login_manager.manager import ComputeScopeBuilder
 
 log = logging.getLogger(__name__)
 
@@ -21,8 +19,7 @@ class ComputeManager(ServiceManager):
 
     def get_scopes(self):
         return [
-            globus_sdk.ComputeClient.scopes.all,
-            globus_sdk.AuthClient.scopes.openid,
+            globus_sdk.ComputeClientV3.scopes.all,
         ]
 
     @property
@@ -33,28 +30,17 @@ class ComputeManager(ServiceManager):
         if getattr(self, "__compute_client", None) is not None:
             return self.__compute_client
 
-        authorizers = self.login_manager.get_manager_authorizers()
-        compute_login_manager = AuthorizerLoginManager(
-            authorizers={
-                globus_sdk.ComputeClient.scopes.resource_server: authorizers.get(
-                    globus_sdk.ComputeClient.scopes.all
-                ),
-                globus_sdk.AuthClient.scopes.resource_server: authorizers.get(
-                    globus_sdk.AuthClient.scopes.openid
-                ),
-            }
-        )
-        try:
-            compute_login_manager.ensure_logged_in()
-        except Exception as e:
-            log.critical(
-                "Gladier failed to properly configure the compute scopes! This is definitely a bug. It would help a lot if you could file a bug report for us <3"
-            )
-            raise
+        auth_params = {}
+
+        if self.login_manager.globus_app:
+            auth_params["login_manager"] = self.login_manager.globus_app
+        else:
+            auth_params[
+                "authorizer"
+            ] = self.login_manager.get_manager_authorizers().get(Client.scopes.all)
 
         self.__compute_client = Client(
-            code_serialization_strategy=self.get_serialization_strategy(),
-            login_manager=compute_login_manager,
+            code_serialization_strategy=self.get_serialization_strategy(), **auth_params
         )
         return self.__compute_client
 

--- a/gladier/managers/login_manager.py
+++ b/gladier/managers/login_manager.py
@@ -19,11 +19,6 @@ from gladier.exc import AuthException
 from gladier.storage.tokens import GladierSecretsConfig
 import globus_compute_sdk
 
-try:
-    import fair_research_login
-except:
-    fair_research_login = None
-
 log = logging.getLogger(__name__)
 
 AUTHORIZER_MAP: TypeAlias = Mapping[
@@ -151,58 +146,6 @@ class BaseLoginManager(abc.ABC):
         after successful login and should not be invoked externally.
         """
         self.scope_changes = set()
-
-
-class AutoLoginManager(BaseLoginManager):
-    """
-    Default Login Manager class in Gladier. Automatically initiates a login if any scope
-    is missing or needs to be updated.
-    """
-
-    refresh_tokens = True
-
-    def __init__(self, client_id: str, storage: Any, app_name: str, auto_login=True):
-        super().__init__()
-        self.storage = storage
-        self.client_id = client_id
-        self.app_name = app_name
-        self.auto_login = auto_login
-
-        if fair_research_login is None:
-            raise ModuleNotFoundError(
-                "Fair Research Login is not installed. You can install it with `pip install fair-research-login`. We recommend using gladier.UserAppLoginManager instead."
-            )
-
-    @property
-    def native_client(self):
-        if getattr(self, "client_id", None) is None:
-            raise AuthException(
-                "Gladier client must be instantiated with a "
-                '"client_id" to use "login()!'
-            )
-        return fair_research_login.NativeClient(
-            client_id=self.client_id, app_name=self.app_name, token_storage=self.storage
-        )
-
-    def get_authorizers(
-        self,
-    ) -> Mapping[str, Union[AccessTokenAuthorizer, RefreshTokenAuthorizer]]:
-        try:
-            return self.native_client.get_authorizers_by_scope()
-        except fair_research_login.LoadError:
-            return dict()
-
-    def login(self, scopes):
-        if self.auto_login is False:
-            raise AuthException(
-                f"Automatic login is disabled. Missing scopes: {scopes}"
-            )
-        self.native_client.login(
-            requested_scopes=scopes, refresh_toknes=self.refresh_tokens, force=True
-        )
-
-    def logout(self):
-        self.native_client.logout()
 
 
 class CallbackLoginManager(BaseLoginManager):

--- a/gladier/managers/login_manager.py
+++ b/gladier/managers/login_manager.py
@@ -35,10 +35,26 @@ class BaseLoginManager(abc.ABC):
     def __init__(self, *args, **kwargs):
         self.required_scopes = set()
         self.scope_changes = set()
+        self.globus_app = None
 
     @property
     def missing_authorizers(self) -> Set[str]:
         return self.get_missing_authorizers(self.get_authorizers())
+
+    def normalize_scope_strs_to_globus_scopes(self, scopes: Iterable[str]) -> Set[str]:
+        """
+        Normalize scopes to a standard format for comparison. This is necessary because scopes can be represented in multiple ways (e.g. as strings or as Scope objects) and we want to ensure that we can accurately determine if the required scopes are present.
+
+        :param scopes: An iterable of scopes to normalize.
+        :return: A set of normalized scope strings.
+        """
+        normalized = set()
+        for scope in scopes:
+            if isinstance(scope, globus_sdk.scopes.Scope):
+                normalized.add(scope)
+            else:
+                normalized.add(globus_sdk.scopes.Scope(scope))
+        return normalized
 
     def get_missing_authorizers(
         self,
@@ -46,7 +62,10 @@ class BaseLoginManager(abc.ABC):
     ) -> Set[str]:
         # Disregard any scopes not in the 'required' list. This allows implementers to return
         # unrelated scopes.
-        absent = self.required_scopes.difference(authorizers)
+        normalized_authorizers = self.normalize_scope_strs_to_globus_scopes(
+            authorizers.keys()
+        )
+        absent = self.required_scopes.difference(normalized_authorizers)
         log.info(
             f"Scopes Absent: {absent or None}, Need Update: {self.scope_changes or None}"
         )
@@ -114,6 +133,7 @@ class BaseLoginManager(abc.ABC):
 
     def add_requirements(self, scopes: Iterable[str]):
         log.debug(f"Added required scopes {scopes}")
+        scopes = self.normalize_scope_strs_to_globus_scopes(scopes)
         self.required_scopes = self.required_scopes | set(scopes)
 
     def add_scope_change(self, scopes: Iterable[str]):
@@ -232,11 +252,13 @@ class ConfidentialClientLoginManager(BaseLoginManager):
         super().__init__()
         self.storage: GladierSecretsConfig = storage
         self.client_id = client_id
-        self.app = ConfidentialAppAuthClient(client_id, client_secret)
+        self.globus_app = ConfidentialAppAuthClient(client_id, client_secret)
 
     def login(self, scopes: List[str]) -> None:
         log.info("Initiating client credentials grant using client_id and secret")
-        response = self.app.oauth2_client_credentials_tokens(requested_scopes=scopes)
+        response = self.globus_app.oauth2_client_credentials_tokens(
+            requested_scopes=scopes
+        )
         self.storage.write_tokens(response.by_resource_server)
 
     def by_scopes(self, tokens):
@@ -268,7 +290,7 @@ class ConfidentialClientLoginManager(BaseLoginManager):
         return {
             scope: RefreshTokenAuthorizer(
                 refresh_token=tdata["refresh_token"],
-                auth_client=self.app,
+                auth_client=self.globus_app,
                 access_token=tdata["access_token"],
                 expires_at=tdata["expires_at_seconds"],
             )
@@ -301,7 +323,7 @@ class UserAppLoginManager(BaseLoginManager):
             globus_auth_parameters or globus_sdk.gare.GlobusAuthorizationParameters()
         )
         self.token_storage = self.get_token_storage()
-        self.user_app = globus_sdk.UserApp(
+        self.globus_app = globus_sdk.UserApp(
             self.app_name,
             client_id=self.client_id,
             config=globus_sdk.GlobusAppConfig(
@@ -319,12 +341,12 @@ class UserAppLoginManager(BaseLoginManager):
             .absolute()
         )
 
-    def get_token_storage(self) -> globus_sdk.tokenstorage.TokenStorage:
+    def get_token_storage(self) -> globus_sdk.token_storage.TokenStorage:
         """
         Uses Gladier Secrets Config to derive the filenames and sections for the Globus App Token Storage configuraiton.
         """
         filepath = self.get_filepath()
-        ts = globus_sdk.tokenstorage.SQLiteTokenStorage(
+        ts = globus_sdk.token_storage.SQLiteTokenStorage(
             filepath, namespace=self.storage_namespace
         )
         log.info(
@@ -349,8 +371,10 @@ class UserAppLoginManager(BaseLoginManager):
         # we have saved to disk. We must ask token storage directly for those.
         tokens_by_rs = self.token_storage.get_token_data_by_resource_server()
         # Determine all scopes saved to disk
-        scopes = globus_sdk.scopes.scopes_to_scope_list(
-            t.scope for t in tokens_by_rs.values()
+        scopes = list(
+            globus_sdk.scopes.ScopeParser.parse(
+                " ".join(t.scope for t in tokens_by_rs.values())
+            )
         )
         tokens_by_scope = {}
         for scope in scopes:
@@ -361,7 +385,7 @@ class UserAppLoginManager(BaseLoginManager):
         # Use the User App to load authorizers for all of the scopes we have. We let the user
         # app do this to handle building the authorizer
         auth_by_scope = {
-            str(scope): self.user_app.get_authorizer(tdata.resource_server)
+            str(scope): self.globus_app.get_authorizer(tdata.resource_server)
             for scope, tdata in tokens_by_scope.items()
         }
         return auth_by_scope
@@ -374,14 +398,14 @@ class UserAppLoginManager(BaseLoginManager):
         # This is a bit unfortunate. add_scope_requirements() requires passing scopes
         # by resource server, which we don't readily have available. That means we need
         # to figure out which resource servers correspond to which scopes.
-        self.user_app.add_scope_requirements(self.scopes_by_resource_server(scopes))
-        self.user_app.login(auth_params=self.globus_auth_parameters)
+        self.globus_app.add_scope_requirements(self.scopes_by_resource_server(scopes))
+        self.globus_app.login(auth_params=self.globus_auth_parameters)
 
     def logout(self):
         """
         Initiate a Globus User App logout. Revokes and clears credentials on this user system.
         """
-        self.user_app.logout()
+        self.globus_app.logout()
 
     def get_resource_server(self, scope):
         """

--- a/gladier/managers/login_manager.py
+++ b/gladier/managers/login_manager.py
@@ -8,7 +8,6 @@ from typing_extensions import TypeAlias
 import abc
 import urllib
 
-import fair_research_login
 import globus_sdk
 from globus_sdk import (
     AccessTokenAuthorizer,
@@ -19,6 +18,11 @@ from globus_sdk.login_flows import CommandLineLoginFlowManager
 from gladier.exc import AuthException
 from gladier.storage.tokens import GladierSecretsConfig
 import globus_compute_sdk
+
+try:
+    import fair_research_login
+except:
+    fair_research_login = None
 
 log = logging.getLogger(__name__)
 
@@ -143,6 +147,11 @@ class AutoLoginManager(BaseLoginManager):
         self.client_id = client_id
         self.app_name = app_name
         self.auto_login = auto_login
+
+        if fair_research_login is None:
+            raise ModuleNotFoundError(
+                "Fair Research Login is not installed. You can install it with `pip install fair-research-login`. We recommend using gladier.UserAppLoginManager instead."
+            )
 
     @property
     def native_client(self):

--- a/gladier/storage/serialization.py
+++ b/gladier/storage/serialization.py
@@ -1,0 +1,104 @@
+"""
+These modules are taken from fair-research-login
+
+https://github.com/fair-research/native-login
+
+Apache License 2.0
+"""
+
+
+def default_name_key(group_key, key):
+    return "{}__{}".format(group_key.replace(".", "_"), key)
+
+
+def default_fetch_key(key):
+    resource_server, token_name = key.split("__")
+    return resource_server.replace("_", "."), token_name
+
+
+def flat_pack(tokens, name_key=default_name_key):
+    """
+    Take a dict of tokens organized by resource server and return a dict
+    that can be easily saved to a config file.
+    Resource servers containing '.' in their name will automatically be
+    converted to '_' (auth.globus.org == auth_globus_org). Tokens by default
+    are prefixed by this name, which you can modify with by setting the
+    name_item() function. An example is here:
+
+    name_item = lambda key, token: '{}_{}'.format(key.replace('.', '_'), token)
+
+    which results in a token name being written as:
+
+    auth_globus_org_access_token = <value>
+
+    Int values are converted to string, None values are converted
+    to empty string. *No other types are checked*.
+    `tokens` should be formatted:
+    {
+        "auth.globus.org": {
+            "scope": "profile openid email",
+            "access_token": "<token>",
+            "refresh_token": None,
+            "token_type": "Bearer",
+            "expires_at_seconds": 1539984535,
+            "resource_server": "auth.globus.org"
+        }, ...
+    }
+    Returns a flat dict of tokens prefixed by resource server.
+    {
+        "auth_globus_org_scope": "profile openid email",
+        "auth_globus_org_access_token": "<token>",
+        "auth_globus_org_refresh_token": "",
+        "auth_globus_org_token_type": "Bearer",
+        "auth_globus_org_expires_at_seconds": "1540051101",
+        "auth_globus_org_resource_server": "auth.globus.org",
+        "token_groups": "auth_globus_org"
+    }"""
+
+    flattened_items = {}
+    for token_set in tokens.values():
+        for key, value in token_set.items():
+            key_name = name_key(token_set["resource_server"], key)
+            if isinstance(value, int):
+                value = str(value)
+            if value is None:
+                value = ""
+            flattened_items[key_name] = value
+
+    return flattened_items
+
+
+def flat_unpack(flat_tokens, fetch_key=default_fetch_key):
+    """
+    Takes a dict from a config section and returns a dict of tokens by
+    resource server. `config_items` is a raw dict of config options
+    returned from get_parser().get_section().
+    Returns tokens in the format:
+    {
+        "auth.globus.org": {
+            "scope": "profile openid email",
+            "access_token": "<token>",
+            "refresh_token": None,
+            "token_type": "Bearer",
+            "expires_at_seconds": 1539984535,
+            "resource_server": "auth.globus.org"
+        }, ...
+    }
+    """
+    if not flat_tokens:
+        return {}
+
+    token_sets = {}
+    for fkey, fvalue in flat_tokens.items():
+        resource_server, key = fetch_key(fkey)
+        tset = token_sets.get(resource_server, {})
+        tset[key] = fvalue or None
+
+        if key == "expires_at_seconds":
+            tset["expires_at_seconds"] = int(tset["expires_at_seconds"])
+
+        token_sets[resource_server] = tset
+    # It's possible for the 'fetch_key' to match the name of the resource
+    # server. This shouldn't matter if we only rely on the key for fetching
+    # items and use the stored value in 'resource_server' for the real name
+    return {tset["resource_server"]: tset for tset in token_sets.values()}

--- a/gladier/storage/tokens.py
+++ b/gladier/storage/tokens.py
@@ -1,7 +1,7 @@
 import os
 import stat
 import logging
-from fair_research_login.token_storage import flat_pack, flat_unpack
+from gladier.storage.serialization import flat_pack, flat_unpack
 from gladier.storage.config import GladierConfig
 
 

--- a/gladier/tests/conftest.py
+++ b/gladier/tests/conftest.py
@@ -157,7 +157,10 @@ def auto_login(logged_in_tokens):
     clm = CallbackLoginManager(
         logged_in_tokens,
         lambda scopes: {
-            scope: globus_sdk.AccessTokenAuthorizer(scope) for scope in scopes
+            scope: globus_sdk.AccessTokenAuthorizer(
+                logged_in_tokens[scope]["access_token"]
+            )
+            for scope in logged_in_tokens
         },
     )
     return clm

--- a/gladier/tests/conftest.py
+++ b/gladier/tests/conftest.py
@@ -4,7 +4,6 @@ import json
 import configparser
 from unittest.mock import Mock, PropertyMock
 import pytest
-import fair_research_login
 from gladier.storage import config, tokens
 import globus_sdk
 
@@ -22,15 +21,6 @@ ALL_FLOW_SCOPES = [
     globus_sdk.FlowsClient.scopes.run_status,
     globus_sdk.FlowsClient.scopes.run_manage,
 ]
-
-
-@pytest.fixture(autouse=True)
-def mock_login(monkeypatch):
-    """Unit tests should never need to call login() or logout(), as doing so
-    would use real developer credentials"""
-    monkeypatch.setattr(fair_research_login.NativeClient, "login", Mock())
-    monkeypatch.setattr(fair_research_login.NativeClient, "logout", Mock())
-    return fair_research_login.NativeClient
 
 
 @pytest.fixture

--- a/gladier/tests/test_data/gladier_mocks.py
+++ b/gladier/tests/test_data/gladier_mocks.py
@@ -1,6 +1,8 @@
 from gladier import GladierBaseTool, GladierBaseClient
 from gladier.decorators import generate_flow_definition
 
+
+mock_flow_id = "mock_tool_flow_scope"
 # Roughly simulates the look of a Globus Automate flow scope
 mock_automate_flow_scope = (
     "https://auth.globus.org/scopes/mock_tool_flow_scope/"

--- a/gladier/tests/test_flows_manager.py
+++ b/gladier/tests/test_flows_manager.py
@@ -7,8 +7,7 @@ from unittest.mock import Mock
 from gladier.exc import ConfigException
 from gladier.managers.flows_manager import FlowsManager
 
-# from gladier.tests.conftest import login_manager
-from gladier.tests.test_data.gladier_mocks import MockGladierClient
+from gladier.tests.test_data.gladier_mocks import MockGladierClient, mock_flow_id
 import gladier
 
 
@@ -76,7 +75,7 @@ def test_custom_scope_id(logged_out):
     cli = MockGladierClient(
         flows_manager=FlowsManager(flow_id="foo"), login_manager=logged_out
     )
-    scope = "https://auth.globus.org/scopes/foo/flow_foo_user"
+    scope = globus_sdk.scopes.Scope("https://auth.globus.org/scopes/foo/flow_foo_user")
     assert scope in cli.login_manager.missing_authorizers
 
 
@@ -94,7 +93,7 @@ def test_unexpected_400_run_flow_without_json(
 ):
     mock_globus_api_error.text = "something that is not JSON!"
     mock_specific_flow_client.run_flow.side_effect = mock_globus_api_error
-    fm = FlowsManager(flow_id="foo", login_manager=auto_login)
+    fm = FlowsManager(flow_id=mock_flow_id, login_manager=auto_login)
     with pytest.raises(globus_sdk.exc.GlobusAPIError):
         fm.run_flow()
 
@@ -109,7 +108,7 @@ def test_dependent_scope_change_run_flow(
     mock_globus_api_error.code = "MISSING_SCOPE"
 
     mock_specific_flow_client.run_flow.side_effect = mock_globus_api_error
-    fm = FlowsManager(flow_id="foo", login_manager=auto_login)
+    fm = FlowsManager(flow_id=mock_flow_id, login_manager=auto_login)
     # Ensure scopes are set, then disable auto_login behavior
     auto_login.get_manager_authorizers()
     auto_login.login = Mock()
@@ -147,7 +146,7 @@ def test_gladier_raises_globus_errors(
 
 def test_flow_definition_changed(auto_login, storage):
     fm = FlowsManager(
-        flow_id="foo", login_manager=auto_login, flow_definition={"foo": "bar"}
+        flow_id=mock_flow_id, login_manager=auto_login, flow_definition={"foo": "bar"}
     )
     fm.storage = storage
     fm.sync_flow()
@@ -158,7 +157,7 @@ def test_flow_definition_changed(auto_login, storage):
 
 def test_schema_changed(auto_login, storage):
     fm = FlowsManager(
-        flow_id="foo", login_manager=auto_login, flow_definition={"foo": "bar"}
+        flow_id=mock_flow_id, login_manager=auto_login, flow_definition={"foo": "bar"}
     )
     fm.storage = storage
     fm.sync_flow()
@@ -169,7 +168,7 @@ def test_schema_changed(auto_login, storage):
 
 def test_flow_kwargs_changed(auto_login, storage):
     fm = FlowsManager(
-        flow_id="foo", login_manager=auto_login, flow_definition={"foo": "bar"}
+        flow_id=mock_flow_id, login_manager=auto_login, flow_definition={"foo": "bar"}
     )
     fm.storage = storage
     fm.sync_flow()
@@ -180,7 +179,7 @@ def test_flow_kwargs_changed(auto_login, storage):
 
 def test_run_flow_run_kwargs(auto_login, storage, mock_specific_flow_client):
     fm = FlowsManager(
-        flow_id="foo",
+        flow_id=mock_flow_id,
         login_manager=auto_login,
         flow_definition={"foo": "bar"},
         run_kwargs={"foo": "bar"},
@@ -195,7 +194,7 @@ def test_run_flow_run_kwargs_conflicting_args(
 ):
     bob_id = "urn:globus:auth:identity:bob@globus.org"
     fm = FlowsManager(
-        flow_id="foo",
+        flow_id=mock_flow_id,
         login_manager=auto_login,
         globus_group="mygroup",
         run_kwargs={"run_managers": [bob_id]},
@@ -235,7 +234,7 @@ def test_run_flow_404_on_explicit_flow_id(
     mock_globus_api_error,
 ):
     fm = FlowsManager(
-        flow_id="foo", flow_definition={"foo": "bar"}, login_manager=auto_login
+        flow_id=mock_flow_id, flow_definition={"foo": "bar"}, login_manager=auto_login
     )
     mock_globus_api_error.http_status = 404
     mock_specific_flow_client.run_flow.side_effect = mock_globus_api_error
@@ -264,7 +263,7 @@ def test_register_flow_404_on_explicit_flow_id(
     auto_login, storage, mock_flows_client, mock_globus_api_error
 ):
     fm = FlowsManager(
-        flow_id="myflow", flow_definition={"foo": "bar"}, login_manager=auto_login
+        flow_id=mock_flow_id, flow_definition={"foo": "bar"}, login_manager=auto_login
     )
     mock_globus_api_error.http_status = 404
     mock_flows_client.update_flow.side_effect = mock_globus_api_error
@@ -277,7 +276,7 @@ def test_register_flow_404_on_explicit_flow_id(
 def test_get_status(
     auto_login, mock_flow_status_active, mock_flows_client, globus_response
 ):
-    fm = FlowsManager(flow_id="foo", login_manager=auto_login)
+    fm = FlowsManager(flow_id=mock_flow_id, login_manager=auto_login)
     globus_response.data = mock_flow_status_active
     mock_flows_client.get_run.return_value = globus_response
     fm.get_status("run_id")
@@ -291,7 +290,7 @@ def test_progress(
     monkeypatch,
 ):
     monkeypatch.setattr(time, "sleep", Mock())
-    fm = FlowsManager(flow_id="foo", login_manager=auto_login)
+    fm = FlowsManager(flow_id=mock_flow_id, login_manager=auto_login)
 
     class GlobusResponse(object):
         _data = [
@@ -314,7 +313,7 @@ def test_progress(
 def test_get_details(
     auto_login, mock_flow_status_succeeded, mock_flows_client, globus_response
 ):
-    fm = FlowsManager(flow_id="foo", login_manager=auto_login)
+    fm = FlowsManager(flow_id=mock_flow_id, login_manager=auto_login)
     globus_response.data = mock_flow_status_succeeded
     mock_flows_client.get_run.return_value = globus_response
     response = fm.get_details("run_id", "ShellCmd")
@@ -326,7 +325,7 @@ def test_flow_manager_flow_permissions(
 ):
     # Test adding flow_kwargs to the FlowsManager
     fm = FlowsManager(
-        flow_id="foo",
+        flow_id=mock_flow_id,
         login_manager=auto_login,
         flow_kwargs={
             "flow_viewers": ["urn:globus:groups:id:mock-user"],
@@ -345,7 +344,7 @@ def test_flow_manager_run_permissions(
 ):
     # Test adding run_kwargs to the FlowsManager
     fm = FlowsManager(
-        flow_id="foo",
+        flow_id=mock_flow_id,
         login_manager=auto_login,
         run_kwargs={
             "run_managers": ["urn:globus:auth:identity:mock-user"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,9 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "globus-sdk>=3.46.0,<4",
-    "globus-compute-sdk>=2.0.1,<3.0.0",
+    "globus-sdk>=4.0.0,<5.0.0",
+    "globus-compute-sdk>=4.0.0,<5.0.0",
     "packaging>=21.3",
-    "fair-research-login>=0.2.6",
     "pydantic>=1.0",
 ]
 license = "Apache-2.0"


### PR DESCRIPTION
Note: This removes support for earlier versions of the Globus SDK (v3 and previous) and Compute SDK (also v3 and previous). Only version 4 of both SDKs will be supported.

This also removes Fair Research Login, which only has support for Globus SDK v3.